### PR TITLE
[Review] Fix : 리뷰 여러번 생성 방지

### DIFF
--- a/mopl-core/src/main/java/com/mopl/moplcore/domain/review/exception/ReviewAlreadyExistsException.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/domain/review/exception/ReviewAlreadyExistsException.java
@@ -1,0 +1,10 @@
+package com.mopl.moplcore.domain.review.exception;
+
+import com.mopl.moplcore.global.exception.BaseException;
+import com.mopl.moplcore.global.exception.ErrorCode;
+
+public class ReviewAlreadyExistsException extends BaseException {
+	public ReviewAlreadyExistsException() {
+		super(ErrorCode.REVIEW_ALREADY_EXISTS);
+	}
+}

--- a/mopl-core/src/main/java/com/mopl/moplcore/domain/review/exception/ReviewNotFoundException.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/domain/review/exception/ReviewNotFoundException.java
@@ -2,8 +2,6 @@ package com.mopl.moplcore.domain.review.exception;
 
 import java.util.UUID;
 
-import org.springframework.http.HttpStatus;
-
 import com.mopl.moplcore.global.exception.BaseException;
 import com.mopl.moplcore.global.exception.ErrorCode;
 
@@ -17,7 +15,7 @@ public class ReviewNotFoundException extends BaseException {
 	}
 
 	public static ReviewNotFoundException withReviewId(UUID reviewId) {
-		return (ReviewNotFoundException) new ReviewNotFoundException()
+		return (ReviewNotFoundException)new ReviewNotFoundException()
 			.addDetail("reviewId", reviewId);
 	}
 }

--- a/mopl-core/src/main/java/com/mopl/moplcore/domain/review/repository/ReviewRepository.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/domain/review/repository/ReviewRepository.java
@@ -10,4 +10,6 @@ import com.mopl.moplcore.domain.review.entity.Review;
 public interface ReviewRepository extends JpaRepository<Review, UUID>, ReviewRepositoryCustom {
 	@Query("SELECT COUNT(r) FROM Review r WHERE r.content.id = :contentId")
 	long count(UUID contentId);
+
+	boolean existsByAuthorIdAndContentId(UUID authorId, UUID contentId);
 }

--- a/mopl-core/src/main/java/com/mopl/moplcore/domain/review/service/ReviewService.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/domain/review/service/ReviewService.java
@@ -15,6 +15,7 @@ import com.mopl.moplcore.domain.review.dto.ReviewSearchRequest;
 import com.mopl.moplcore.domain.review.dto.ReviewUpdateRequest;
 import com.mopl.moplcore.domain.review.entity.Review;
 import com.mopl.moplcore.domain.review.exception.ForbiddenReviewAccessException;
+import com.mopl.moplcore.domain.review.exception.ReviewAlreadyExistsException;
 import com.mopl.moplcore.domain.review.exception.ReviewNotFoundException;
 import com.mopl.moplcore.domain.review.mapper.ReviewMapper;
 import com.mopl.moplcore.domain.review.repository.ReviewRepository;
@@ -35,6 +36,10 @@ public class ReviewService {
 
 	@Transactional
 	public ReviewDto create(ReviewCreateRequest request, UUID authorId) {
+		if (reviewRepository.existsByAuthorIdAndContentId(authorId, request.contentId())) {
+			throw new ReviewAlreadyExistsException();
+		}
+
 		/* TODO : User, Content 있는지 확인하는 검증 라인
 		    다른 도메인 예외 추가시 변경
 		User author = userRepository.findById(authorId)

--- a/mopl-core/src/main/java/com/mopl/moplcore/global/exception/ErrorCode.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/global/exception/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
 	INVALID_RATING(HttpStatus.BAD_REQUEST, "평점은 1.0 ~ 5.0 사이여야 합니다"),
 	FORBIDDEN_REVIEW_ACCESS(HttpStatus.FORBIDDEN, "본인의 리뷰만 수정/삭제할 수 있습니다"),
 	INVALID_REVIEW_TEXT(HttpStatus.BAD_REQUEST, "리뷰 내용은 공백일 수 없습니다"),
+	REVIEW_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 해당 콘텐츠에 리뷰를 작성하셨습니다"),
 
     PLAYLIST_NOT_FOUND(HttpStatus.NOT_FOUND, "플레이리스트를 찾을 수 없습니다"),
     PLAYLIST_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "플레이리스트 생성 한도를 초과했습니다"),


### PR DESCRIPTION
## PR 요약
<!-- 이번 PR의 목적과 변경 사항을 간단히 작성해주세요.-->
한 컨텐츠에 한 유저가 여러번 리뷰를 남기면 의도적으로 별점을 높이거나 낮출수 있기 때문에
단 한번만 작성하는 것이 비즈니스 규칙이었는데 이전에 적용시키지 않았어서
중복 생성을 막는 기능을 추가했습니다.

## 체크리스트
- [x] 이 PR과 관련된 이슈가 있나요? (#11)
- [x] 기능/버그 수정 테스트 완료
- [ ] 코드 리뷰 완료


## 상세 설명
<!-- 변경 사항, 추가된 기능, 버그 수정 내용 등을 자세히 작성해주세요.-->
repository에서 작성된 리뷰가 있는지 검색 메서드 추가
서비스에서 생성 시 중복 검증 시도
관련 에러코드 및 예외 추가

ReviewNotFoundExeception의 경우 불필요한 HttpStatus가 import 있어서 제거했습니다.
## 검증 단계
<!-- 
PR을 적용하기 전에 확인한 사항과 테스트 방법을 작성해주세요.
예시:
1. 로컬 서버 실행 후 API 정상 동작 확인
2. 신규 기능 UI/UX 테스트 완료
3. 기존 기능 회귀 테스트 완료
-->
Postman
- [x] 더미 데이터에 작성된 유저로 리뷰작성 시도
- [x] 아예 리뷰를 안 쓴 글에 동일 리뷰 여러번 시도  

## 추가 코멘트
<!-- 팀원에게 공유할 필요가 있는 추가 정보나 주석 등을 작성해주세요.-->
