### PR TITLE
[Follow] 팔로우 조회 기능 추가

### DIFF
--- a/mopl-core/src/main/java/com/mopl/moplcore/domain/follow/controller/FollowController.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/domain/follow/controller/FollowController.java
@@ -5,10 +5,12 @@ import java.util.UUID;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.mopl.moplcore.domain.follow.dto.FollowDto;
@@ -39,5 +41,19 @@ public class FollowController {
 		followService.cancel(followId, TEMP_FOLLOWER_ID);
 
 		return ResponseEntity.noContent().build();
+	}
+
+	@GetMapping("/followed-by-me")
+	public ResponseEntity<Boolean> isFollowedByMe(@RequestParam UUID followeeId) {
+		boolean isFollowed = followService.isFollowedByMe(TEMP_FOLLOWER_ID, followeeId);
+
+		return ResponseEntity.ok(isFollowed);
+	}
+
+	@GetMapping("/count")
+	public ResponseEntity<Long> countFollowers(@RequestParam UUID followeeId) {
+		long followerCount = followService.countFollowers(followeeId);
+
+		return ResponseEntity.ok(followerCount);
 	}
 }

--- a/mopl-core/src/main/java/com/mopl/moplcore/domain/follow/repository/FollowRepository.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/domain/follow/repository/FollowRepository.java
@@ -9,4 +9,6 @@ import com.mopl.moplcore.domain.user.entity.Follow;
 public interface FollowRepository extends JpaRepository<Follow, UUID> {
 
 	boolean existsByFollowerIdAndFolloweeId(UUID followerId, UUID followeeId);
+
+	long countByFolloweeId(UUID followeeId);
 }

--- a/mopl-core/src/main/java/com/mopl/moplcore/domain/follow/service/FollowService.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/domain/follow/service/FollowService.java
@@ -64,4 +64,14 @@ public class FollowService {
 
 		followRepository.delete(follow);
 	}
+
+	@Transactional(readOnly = true)
+	public boolean isFollowedByMe(UUID followerId, UUID followeeId) {
+		return followRepository.existsByFollowerIdAndFolloweeId(followerId, followeeId);
+	}
+
+	@Transactional(readOnly = true)
+	public long countFollowers(UUID followeeId) {
+		return followRepository.countByFolloweeId(followeeId);
+	}
 }


### PR DESCRIPTION
- FollowRepository FollowRepository.countByFolloweeId FolloweeId를 팔로우한 수를 세는 메서드

- FollowService FollowService.isFollowedByMe(followerId, followeeId) followerId가 followeeId를 이미 팔로우 했는지 boolean으로 반환하는 서비스 메서드

FollowService.countFollowers(followeeId)
followeeId의 팔로우 수를 반환하는 메서드

-FollowController
/api/follows/followed-by-me,
/api/follows/count 엔드포인트 추가

## PR 요약
<!-- 이번 PR의 목적과 변경 사항을 간단히 작성해주세요.-->
팔로우에서 해당 유저를 이미 팔로우 했는지
또 팔로워의 수가 얼마나 되는지 반환하는 기능을 구현했습니다.

## 체크리스트
- [x] 이 PR과 관련된 이슈가 있나요? (#21)
- [x] 기능/버그 수정 테스트 완료
- [ ] 코드 리뷰 완료


## 상세 설명
<!-- 변경 사항, 추가된 기능, 버그 수정 내용 등을 자세히 작성해주세요.-->
- FollowRepository
FollowRepository.countByFolloweeId FolloweeId를 팔로우한 수를 세는 메서드

- FollowService
FollowService.isFollowedByMe(followerId, followeeId) followerId가 followeeId를 이미 팔로우 했는지 boolean으로 반환하는 서비스 메서드

FollowService.countFollowers(followeeId)
followeeId의 팔로우 수를 반환하는 메서드

-FollowController
/api/follows/followed-by-me,
/api/follows/count 엔드포인트 추가

## 검증 단계
<!-- 
PR을 적용하기 전에 확인한 사항과 테스트 방법을 작성해주세요.
예시:
1. 로컬 서버 실행 후 API 정상 동작 확인
2. 신규 기능 UI/UX 테스트 완료
3. 기존 기능 회귀 테스트 완료
-->
Postman에서 API 테스트
### 팔로우 했는지 체크 기능
- 성공 시나리오
1. 팔로우 유저 체크 시 true 반환
2. 팔로우 안한 유저 체크 시 false 반환
3. 존재 하지 않는 유저 ID로 체크 시 false 반환

### 팔로워 수 세기
- 성공 시나리오
1. 팔로워 수 조회 이후 실제 팔로워 수 비교 (long 반환)

존재 하지 않는 유저를 팔로우 했는지 체크 할 때 error로 처리할 지
아니면 그냥 검증 없이 false로 모두 처리할 지 고민입니다.

실패 시나리오에 에러가 있으면 넣을거고 아니면 각각
false와 0 을 반환하는게 정상작동으로 보고 있습니다.

## 추가 코멘트
<!-- 팀원에게 공유할 필요가 있는 추가 정보나 주석 등을 작성해주세요.-->

JPA에서 자동생성되는 쿼리문을 믿고 쓰는데
실제로는 불필요한 join을 하더라고요.

예를 들어서
follow 테이블에 이미 두 개의 follower와 followee가 있는데 JPA에서는 사실 관계 테이블로 인식이 되어서
두개의 user를 left join하는 식으로 만들어 지는데
쿼리나 네이티브 쿼리로 짜면 postgreSQL의 문법에 종속되기도 한 점도 있어서 일단은 냅뒀는데요

이후 이런 부분도 최적화가 필요하다는 피드백이 오면 리팩토링 하겠습니다.