### PR TITLE
[Playlist] 플레이리스트 CRUD 및 구독 관리 API 구현

### DIFF
--- a/mopl-core/src/main/java/com/mopl/moplcore/domain/content/dto/ContentSummary.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/domain/content/dto/ContentSummary.java
@@ -1,0 +1,23 @@
+package com.mopl.moplcore.domain.content.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+import com.mopl.moplcore.domain.content.entity.Type;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Schema(description = "콘텐츠 요약 정보")
+@Builder
+public record ContentSummary(
+	UUID id,
+	Type type,
+	String title,
+	String description,
+	String thumbnailUrl,
+	List<String> tags,
+	Double averageRating,
+	Integer reviewCount
+) {
+}

--- a/mopl-core/src/main/java/com/mopl/moplcore/domain/playlist/controller/PlaylistController.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/domain/playlist/controller/PlaylistController.java
@@ -1,0 +1,145 @@
+package com.mopl.moplcore.domain.playlist.controller;
+
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.mopl.moplcore.domain.playlist.dto.CursorResponsePlaylistDto;
+import com.mopl.moplcore.domain.playlist.dto.PlaylistCreateRequest;
+import com.mopl.moplcore.domain.playlist.dto.PlaylistDto;
+import com.mopl.moplcore.domain.playlist.dto.PlaylistSearchRequest;
+import com.mopl.moplcore.domain.playlist.dto.PlaylistUpdateRequest;
+import com.mopl.moplcore.domain.playlist.service.PlaylistService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/playlists")
+@RequiredArgsConstructor
+public class PlaylistController {
+
+	private final PlaylistService playlistService;
+
+	private UUID getCurrentUserId() {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+		if (authentication == null || !authentication.isAuthenticated()) {
+			return null;
+		}
+
+		Object principal = authentication.getPrincipal();
+		if (principal instanceof UUID) {
+			return (UUID) principal;
+		}
+
+		return null;
+	}
+
+	@Operation(summary = "플레이리스트 목록 조회")
+	@GetMapping
+	public ResponseEntity<CursorResponsePlaylistDto> searchPlaylists(
+		@Valid @ModelAttribute PlaylistSearchRequest request
+	) {
+		UUID currentUserId = getCurrentUserId();
+		CursorResponsePlaylistDto response = playlistService.searchPlaylists(request, currentUserId);
+		return ResponseEntity.ok(response);
+	}
+
+	@Operation(summary = "플레이리스트 상세 조회")
+	@GetMapping("/{playlistId}")
+	public ResponseEntity<PlaylistDto> getPlaylist(
+		@PathVariable UUID playlistId
+	) {
+		UUID currentUserId = getCurrentUserId();
+		PlaylistDto response = playlistService.getPlaylist(playlistId, currentUserId);
+		return ResponseEntity.ok(response);
+	}
+
+	@Operation(summary = "플레이리스트 생성")
+	@PostMapping
+	public ResponseEntity<PlaylistDto> createPlaylist(
+		@Valid @RequestBody PlaylistCreateRequest request
+	) {
+		UUID currentUserId = getCurrentUserId();
+		PlaylistDto response = playlistService.createPlaylist(currentUserId, request);
+		return ResponseEntity.status(HttpStatus.CREATED).body(response);
+	}
+
+	@Operation(summary = "플레이리스트 수정")
+	@PatchMapping("/{playlistId}")
+	public ResponseEntity<PlaylistDto> updatePlaylist(
+		@PathVariable UUID playlistId,
+		@Valid @RequestBody PlaylistUpdateRequest request
+	) {
+		UUID currentUserId = getCurrentUserId();
+		PlaylistDto response = playlistService.updatePlaylist(playlistId, currentUserId, request);
+		return ResponseEntity.ok(response);
+	}
+
+	@Operation(summary = "플레이리스트 삭제")
+	@DeleteMapping("/{playlistId}")
+	public ResponseEntity<Void> deletePlaylist(
+		@PathVariable UUID playlistId
+	) {
+		UUID currentUserId = getCurrentUserId();
+		playlistService.deletePlaylist(playlistId, currentUserId);
+		return ResponseEntity.ok().build();
+	}
+
+	@Operation(summary = "플레이리스트에 콘텐츠 추가")
+	@PostMapping("/{playlistId}/contents/{contentId}")
+	public ResponseEntity<Void> addContentToPlaylist(
+		@PathVariable UUID playlistId,
+		@PathVariable UUID contentId
+	) {
+		UUID currentUserId = getCurrentUserId();
+		playlistService.addContentToPlaylist(playlistId, contentId, currentUserId);
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+	}
+
+	@Operation(summary = "플레이리스트에서 콘텐츠 제거")
+	@DeleteMapping("/{playlistId}/contents/{contentId}")
+	public ResponseEntity<Void> removeContentFromPlaylist(
+		@PathVariable UUID playlistId,
+		@PathVariable UUID contentId
+	) {
+		UUID currentUserId = getCurrentUserId();
+		playlistService.removeContentFromPlaylist(playlistId, contentId, currentUserId);
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+	}
+
+	@Operation(summary = "플레이리스트 구독")
+	@PostMapping("/{playlistId}/subscription")
+	public ResponseEntity<Void> subscribePlaylist(
+		@PathVariable UUID playlistId
+	) {
+		UUID currentUserId = getCurrentUserId();
+		playlistService.subscribePlaylist(playlistId, currentUserId);
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+	}
+
+	@Operation(summary = "플레이리스트 구독 취소")
+	@DeleteMapping("/{playlistId}/subscription")
+	public ResponseEntity<Void> unsubscribePlaylist(
+		@PathVariable UUID playlistId
+	) {
+		UUID currentUserId = getCurrentUserId();
+		playlistService.unsubscribePlaylist(playlistId, currentUserId);
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+	}
+}

--- a/mopl-core/src/main/java/com/mopl/moplcore/domain/playlist/dto/CursorResponsePlaylistDto.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/domain/playlist/dto/CursorResponsePlaylistDto.java
@@ -1,0 +1,19 @@
+package com.mopl.moplcore.domain.playlist.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CursorResponsePlaylistDto {
+	private List<PlaylistDto> data;
+	private String nextCursor;
+	private UUID nextIdAfter;
+	private boolean hasNext;
+	private long totalCount;
+	private String sortBy;
+	private String sortDirection;
+}

--- a/mopl-core/src/main/java/com/mopl/moplcore/domain/playlist/dto/PlaylistCreateRequest.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/domain/playlist/dto/PlaylistCreateRequest.java
@@ -1,0 +1,13 @@
+package com.mopl.moplcore.domain.playlist.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PlaylistCreateRequest(
+
+	@NotBlank(message = "플레이리스트 제목은 필수입니다")
+	String title,
+
+	@NotBlank(message = "플레이리스트 설명은 필수입니다")
+	String description
+) {
+}

--- a/mopl-core/src/main/java/com/mopl/moplcore/domain/playlist/dto/PlaylistDto.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/domain/playlist/dto/PlaylistDto.java
@@ -1,0 +1,22 @@
+package com.mopl.moplcore.domain.playlist.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import com.mopl.moplcore.domain.content.dto.ContentSummary;
+import com.mopl.moplcore.domain.user.dto.UserSummary;
+import lombok.Builder;
+
+@Builder
+public record PlaylistDto(
+	UUID id,
+	UserSummary owner,
+	String title,
+	String description,
+	LocalDateTime updatedAt,
+	Long subscriberCount,
+	Boolean subscribedByMe,
+	List<ContentSummary> contents
+) {
+}

--- a/mopl-core/src/main/java/com/mopl/moplcore/domain/playlist/dto/PlaylistSearchRequest.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/domain/playlist/dto/PlaylistSearchRequest.java
@@ -1,0 +1,37 @@
+package com.mopl.moplcore.domain.playlist.dto;
+
+import java.util.UUID;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PlaylistSearchRequest {
+	private String keywordLike;
+	private UUID ownerIdEqual;
+	private UUID subscriberIdEqual;
+	private String cursor;
+	private UUID idAfter;
+
+	@NotNull(message = "limit은 필수입니다")
+	private Integer limit;
+
+	@NotNull(message = "sortDirection은 필수입니다")
+	private SortDirection sortDirection;
+
+	@NotNull(message = "sortBy는 필수입니다")
+	private PlaylistSortBy sortBy;
+
+	public enum PlaylistSortBy {
+		updatedAt,
+		subscribeCount
+	}
+
+	public enum SortDirection {
+		ASCENDING,
+		DESCENDING
+	}
+}

--- a/mopl-core/src/main/java/com/mopl/moplcore/domain/playlist/dto/PlaylistUpdateRequest.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/domain/playlist/dto/PlaylistUpdateRequest.java
@@ -1,0 +1,7 @@
+package com.mopl.moplcore.domain.playlist.dto;
+
+public record PlaylistUpdateRequest(
+	String title,
+	String description
+) {
+}

--- a/mopl-core/src/main/java/com/mopl/moplcore/domain/playlist/exception/PlaylistNotFoundException.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/domain/playlist/exception/PlaylistNotFoundException.java
@@ -1,0 +1,13 @@
+package com.mopl.moplcore.domain.playlist.exception;
+
+import java.util.UUID;
+
+import com.mopl.moplcore.global.exception.BaseException;
+import com.mopl.moplcore.global.exception.ErrorCode;
+
+public class PlaylistNotFoundException extends BaseException {
+	public PlaylistNotFoundException(UUID id) {
+		super(ErrorCode.PLAYLIST_NOT_FOUND);
+		addDetail("playlistId", id);
+	}
+}

--- a/mopl-core/src/main/java/com/mopl/moplcore/domain/playlist/repository/PlaylistContentRepository.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/domain/playlist/repository/PlaylistContentRepository.java
@@ -1,0 +1,17 @@
+package com.mopl.moplcore.domain.playlist.repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.mopl.moplcore.domain.playlist.entity.PlaylistContent;
+
+public interface PlaylistContentRepository extends JpaRepository<PlaylistContent, UUID> {
+	List<PlaylistContent> findByPlaylistId(UUID playlistId);
+	
+	Optional<PlaylistContent> findByPlaylistIdAndContentId(UUID playlistId, UUID contentId);
+	
+	void deleteByPlaylistIdAndContentId(UUID playlistId, UUID contentId);
+}

--- a/mopl-core/src/main/java/com/mopl/moplcore/domain/playlist/repository/PlaylistRepository.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/domain/playlist/repository/PlaylistRepository.java
@@ -1,0 +1,11 @@
+package com.mopl.moplcore.domain.playlist.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.mopl.moplcore.domain.playlist.entity.Playlist;
+
+public interface PlaylistRepository extends JpaRepository<Playlist, UUID>, PlaylistRepositoryCustom {
+
+}

--- a/mopl-core/src/main/java/com/mopl/moplcore/domain/playlist/repository/PlaylistRepositoryCustom.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/domain/playlist/repository/PlaylistRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.mopl.moplcore.domain.playlist.repository;
+
+import java.util.List;
+
+import com.mopl.moplcore.domain.playlist.dto.PlaylistSearchRequest;
+import com.mopl.moplcore.domain.playlist.entity.Playlist;
+
+public interface PlaylistRepositoryCustom {
+	List<Playlist> searchPlaylists(PlaylistSearchRequest request);
+	Long countPlaylists(PlaylistSearchRequest request);
+}

--- a/mopl-core/src/main/java/com/mopl/moplcore/domain/playlist/repository/PlaylistRepositoryImpl.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/domain/playlist/repository/PlaylistRepositoryImpl.java
@@ -1,0 +1,96 @@
+package com.mopl.moplcore.domain.playlist.repository;
+
+import java.util.List;
+import java.util.UUID;
+
+import com.mopl.moplcore.domain.playlist.dto.PlaylistSearchRequest;
+import com.mopl.moplcore.domain.playlist.entity.Playlist;
+import com.mopl.moplcore.domain.playlist.entity.QPlaylist;
+import com.mopl.moplcore.domain.playlist.entity.QPlaylistSubscription;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class PlaylistRepositoryImpl implements PlaylistRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public List<Playlist> searchPlaylists(PlaylistSearchRequest request) {
+		QPlaylist playlist = QPlaylist.playlist;
+
+		return queryFactory
+			.selectFrom(playlist)
+			.leftJoin(playlist.owner).fetchJoin()
+			.where(
+				keywordLike(request.getKeywordLike()),
+				ownerIdEqual(request.getOwnerIdEqual()),
+				subscriberIdEqual(request.getSubscriberIdEqual())
+			)
+			.orderBy(getOrderSpecifier(request))
+			.limit(request.getLimit() + 1)
+			.fetch();
+	}
+
+	@Override
+	public Long countPlaylists(PlaylistSearchRequest request) {
+		QPlaylist playlist = QPlaylist.playlist;
+
+		return queryFactory
+			.select(playlist.count())
+			.from(playlist)
+			.where(
+				keywordLike(request.getKeywordLike()),
+				ownerIdEqual(request.getOwnerIdEqual()),
+				subscriberIdEqual(request.getSubscriberIdEqual())
+			)
+			.fetchOne();
+	}
+
+	private BooleanExpression keywordLike(String keyword) {
+		if (keyword == null || keyword.trim().isEmpty()) {
+			return null;
+		}
+		QPlaylist playlist = QPlaylist.playlist;
+		return playlist.title.containsIgnoreCase(keyword)
+			.or(playlist.description.containsIgnoreCase(keyword));
+	}
+
+	private BooleanExpression ownerIdEqual(UUID ownerId) {
+		if (ownerId == null) {
+			return null;
+		}
+		return QPlaylist.playlist.owner.id.eq(ownerId);
+	}
+
+	private BooleanExpression subscriberIdEqual(UUID subscriberId) {
+		if (subscriberId == null) {
+			return null;
+		}
+
+		QPlaylist playlist = QPlaylist.playlist;
+		QPlaylistSubscription subscription = QPlaylistSubscription.playlistSubscription;
+
+		return playlist.id.in(
+			JPAExpressions
+				.select(subscription.playlist.id)
+				.from(subscription)
+				.where(subscription.user.id.eq(subscriberId))
+		);
+	}
+
+	private OrderSpecifier<?> getOrderSpecifier(PlaylistSearchRequest request) {
+		QPlaylist playlist = QPlaylist.playlist;
+
+		boolean isAsc = request.getSortDirection() == PlaylistSearchRequest.SortDirection.ASCENDING;
+
+		return switch (request.getSortBy()) {
+			case updatedAt -> isAsc ? playlist.updatedAt.asc() : playlist.updatedAt.desc();
+			case subscribeCount -> throw new UnsupportedOperationException("subscribeCount 정렬은 아직 미구현");
+		};
+	}
+}

--- a/mopl-core/src/main/java/com/mopl/moplcore/domain/playlist/repository/PlaylistSubscriptionRepository.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/domain/playlist/repository/PlaylistSubscriptionRepository.java
@@ -1,0 +1,20 @@
+package com.mopl.moplcore.domain.playlist.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.mopl.moplcore.domain.playlist.entity.PlaylistSubscription;
+
+public interface PlaylistSubscriptionRepository extends JpaRepository<PlaylistSubscription, UUID> {
+	Long countByPlaylistId(UUID playlistId);
+	Optional<PlaylistSubscription> findByPlaylistIdAndUserId(UUID playlistId, UUID userId);
+	@Modifying
+	@Query("DELETE FROM PlaylistSubscription ps WHERE ps.playlist.id = :playlistId AND ps.user.id = :userId")
+	void deleteByPlaylistIdAndUserId(@Param("playlistId") UUID playlistId, @Param("userId") UUID userId);
+	boolean existsByPlaylistIdAndUserId(UUID playlistId, UUID userId);
+}

--- a/mopl-core/src/main/java/com/mopl/moplcore/domain/playlist/service/PlaylistService.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/domain/playlist/service/PlaylistService.java
@@ -1,0 +1,251 @@
+package com.mopl.moplcore.domain.playlist.service;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.mopl.moplcore.domain.content.dto.ContentSummary;
+import com.mopl.moplcore.domain.content.entity.Content;
+import com.mopl.moplcore.domain.content.entity.Type;
+import com.mopl.moplcore.domain.content.exception.ContentNotFoundException;
+import com.mopl.moplcore.domain.content.repository.ContentRepository;
+import com.mopl.moplcore.domain.content.repository.ContentTagRepository;
+import com.mopl.moplcore.domain.playlist.dto.CursorResponsePlaylistDto;
+import com.mopl.moplcore.domain.playlist.dto.PlaylistCreateRequest;
+import com.mopl.moplcore.domain.playlist.dto.PlaylistDto;
+import com.mopl.moplcore.domain.playlist.dto.PlaylistSearchRequest;
+import com.mopl.moplcore.domain.playlist.dto.PlaylistUpdateRequest;
+import com.mopl.moplcore.domain.playlist.entity.Playlist;
+import com.mopl.moplcore.domain.playlist.entity.PlaylistContent;
+import com.mopl.moplcore.domain.playlist.entity.PlaylistSubscription;
+import com.mopl.moplcore.domain.playlist.exception.PlaylistNotFoundException;
+import com.mopl.moplcore.domain.playlist.repository.PlaylistContentRepository;
+import com.mopl.moplcore.domain.playlist.repository.PlaylistRepository;
+import com.mopl.moplcore.domain.playlist.repository.PlaylistSubscriptionRepository;
+import com.mopl.moplcore.domain.user.dto.UserSummary;
+import com.mopl.moplcore.domain.user.entity.User;
+import com.mopl.moplcore.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PlaylistService {
+
+	private static final String TMDB_IMAGE_BASE_URL = "https://image.tmdb.org/t/p/w500";
+
+	private final PlaylistRepository playlistRepository;
+	private final PlaylistContentRepository playlistContentRepository;
+	private final PlaylistSubscriptionRepository playlistSubscriptionRepository;
+	private final ContentRepository contentRepository;
+	private final ContentTagRepository contentTagRepository;
+	private final UserRepository userRepository;
+
+	@Transactional
+	public PlaylistDto createPlaylist(UUID userId, PlaylistCreateRequest request) {
+		User owner = userRepository.findById(userId)
+			.orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다"));
+
+		Playlist playlist = new Playlist(owner, request.title(), request.description());
+		Playlist savedPlaylist = playlistRepository.save(playlist);
+
+		return toDto(savedPlaylist, userId);
+	}
+
+	public CursorResponsePlaylistDto searchPlaylists(PlaylistSearchRequest request, UUID currentUserId) {
+		List<Playlist> playlists = playlistRepository.searchPlaylists(request);
+		Long totalCount = playlistRepository.countPlaylists(request);
+
+		boolean hasNext = playlists.size() > request.getLimit();
+		if (hasNext) {
+			playlists = playlists.subList(0, request.getLimit());
+		}
+
+		List<PlaylistDto> playlistDtos = playlists.stream()
+			.map(playlist -> toDto(playlist, currentUserId))
+			.toList();
+
+		String nextCursor = null;
+		if (hasNext && !playlists.isEmpty()) {
+			Playlist lastPlaylist = playlists.get(playlists.size() - 1);
+			nextCursor = encodeCursor(lastPlaylist.getId(), lastPlaylist.getUpdatedAt());
+		}
+
+		return CursorResponsePlaylistDto.builder()
+			.data(playlistDtos)
+			.nextCursor(nextCursor)
+			.nextIdAfter(hasNext && !playlists.isEmpty() ? playlists.get(playlists.size() - 1).getId() : null)
+			.hasNext(hasNext)
+			.totalCount(totalCount)
+			.sortBy(request.getSortBy().name())
+			.sortDirection(request.getSortDirection().name())
+			.build();
+	}
+
+	public PlaylistDto getPlaylist(UUID playlistId, UUID currentUserId) {
+		Playlist playlist = playlistRepository.findById(playlistId)
+			.orElseThrow(() -> new PlaylistNotFoundException(playlistId));
+
+		return toDto(playlist, currentUserId);
+	}
+
+	@Transactional
+	public PlaylistDto updatePlaylist(UUID playlistId, UUID userId, PlaylistUpdateRequest request) {
+		Playlist playlist = playlistRepository.findById(playlistId)
+			.orElseThrow(() -> new PlaylistNotFoundException(playlistId));
+
+		if (!playlist.getOwner().getId().equals(userId)) {
+			throw new IllegalArgumentException("플레이리스트 소유자만 수정할 수 있습니다");
+		}
+
+		playlist.update(request.title(), request.description());
+
+		return toDto(playlist, userId);
+	}
+
+	@Transactional
+	public void deletePlaylist(UUID playlistId, UUID userId) {
+		Playlist playlist = playlistRepository.findById(playlistId)
+			.orElseThrow(() -> new PlaylistNotFoundException(playlistId));
+
+		if (!playlist.getOwner().getId().equals(userId)) {
+			throw new IllegalArgumentException("플레이리스트 소유자만 삭제할 수 있습니다");
+		}
+
+		playlistRepository.delete(playlist);
+	}
+
+	@Transactional
+	public void addContentToPlaylist(UUID playlistId, UUID contentId, UUID userId) {
+		Playlist playlist = playlistRepository.findById(playlistId)
+			.orElseThrow(() -> new PlaylistNotFoundException(playlistId));
+
+		if (!playlist.getOwner().getId().equals(userId)) {
+			throw new IllegalArgumentException("플레이리스트 소유자만 콘텐츠를 추가할 수 있습니다");
+		}
+
+		Content content = contentRepository.findById(contentId)
+			.orElseThrow(() -> new ContentNotFoundException(contentId));
+
+		if (playlistContentRepository.findByPlaylistIdAndContentId(playlistId, contentId).isPresent()) {
+			throw new IllegalArgumentException("이미 플레이리스트에 추가된 콘텐츠입니다");
+		}
+
+		PlaylistContent playlistContent = new PlaylistContent(playlist, content);
+		playlistContentRepository.save(playlistContent);
+	}
+
+	@Transactional
+	public void removeContentFromPlaylist(UUID playlistId, UUID contentId, UUID userId) {
+		Playlist playlist = playlistRepository.findById(playlistId)
+			.orElseThrow(() -> new PlaylistNotFoundException(playlistId));
+
+		if (!playlist.getOwner().getId().equals(userId)) {
+			throw new IllegalArgumentException("플레이리스트 소유자만 콘텐츠를 삭제할 수 있습니다");
+		}
+
+		playlistContentRepository.deleteByPlaylistIdAndContentId(playlistId, contentId);
+	}
+
+	@Transactional
+	public void subscribePlaylist(UUID playlistId, UUID userId) {
+		Playlist playlist = playlistRepository.findById(playlistId)
+			.orElseThrow(() -> new PlaylistNotFoundException(playlistId));
+
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다"));
+
+		if (playlistSubscriptionRepository.existsByPlaylistIdAndUserId(playlistId, userId)) {
+			throw new IllegalArgumentException("이미 구독한 플레이리스트입니다");
+		}
+
+		PlaylistSubscription subscription = new PlaylistSubscription(playlist, user);
+		playlistSubscriptionRepository.save(subscription);
+	}
+
+	@Transactional
+	public void unsubscribePlaylist(UUID playlistId, UUID userId) {
+		playlistSubscriptionRepository.deleteByPlaylistIdAndUserId(playlistId, userId);
+	}
+
+	private PlaylistDto toDto(Playlist playlist, UUID currentUserId) {
+		UserSummary owner = new UserSummary(
+			playlist.getOwner().getId(),
+			playlist.getOwner().getName(),
+			playlist.getOwner().getProfileImageUrl()
+		);
+
+		Long subscriberCount = playlistSubscriptionRepository.countByPlaylistId(playlist.getId());
+
+		Boolean subscribedByMe = currentUserId != null &&
+			playlistSubscriptionRepository.existsByPlaylistIdAndUserId(playlist.getId(), currentUserId);
+
+		List<ContentSummary> contents = playlistContentRepository.findByPlaylistId(playlist.getId())
+			.stream()
+			.map(pc -> toContentSummary(pc.getContent()))
+			.toList();
+
+		LocalDateTime updatedAtLocal = LocalDateTime.ofInstant(
+			playlist.getUpdatedAt(),
+			java.time.ZoneId.systemDefault()
+		);
+
+		return PlaylistDto.builder()
+			.id(playlist.getId())
+			.owner(owner)
+			.title(playlist.getTitle())
+			.description(playlist.getDescription())
+			.updatedAt(updatedAtLocal)
+			.subscriberCount(subscriberCount)
+			.subscribedByMe(subscribedByMe)
+			.contents(contents)
+			.build();
+	}
+
+	private ContentSummary toContentSummary(Content content) {
+		List<String> tags = contentTagRepository.findByContentId(content.getId())
+			.stream()
+			.map(ct -> ct.getTag().getName())
+			.toList();
+
+		String fullThumbnailUrl = buildImageUrl(content.getType(), content.getThumbnailUrl());
+
+		return ContentSummary.builder()
+			.id(content.getId())
+			.type(content.getType())
+			.title(content.getTitle())
+			.description(content.getDescription())
+			.thumbnailUrl(fullThumbnailUrl)
+			.tags(tags)
+			.averageRating(content.getAverageRating())
+			.reviewCount(content.getReviewCount())
+			.build();
+	}
+
+	private String buildImageUrl(Type type, String path) {
+		if (path == null) {
+			return null;
+		}
+
+		if (path.startsWith("http://") || path.startsWith("https://")) {
+			return path;
+		}
+
+		return switch (type) {
+			case MOVIE, TV_SERIES -> TMDB_IMAGE_BASE_URL + path;
+			case SPORTS -> path;
+		};
+	}
+
+	private String encodeCursor(UUID id, Instant updatedAt) {
+		String raw = id.toString() + "|" + updatedAt.toString();
+		return java.util.Base64.getUrlEncoder()
+			.withoutPadding()
+			.encodeToString(raw.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+	}
+}

--- a/mopl-core/src/main/java/com/mopl/moplcore/global/config/S3Config.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/global/config/S3Config.java
@@ -1,0 +1,34 @@
+package com.mopl.moplcore.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+@Configuration
+public class S3Config {
+
+	@Value("${cloud.aws.credentials.access-key}")
+	private String accessKey;
+
+	@Value("${cloud.aws.credentials.secret-key}")
+	private String secretKey;
+
+	@Value("${cloud.aws.region.static}")
+	private String region;
+
+	@Bean
+	public AmazonS3 amazonS3() {
+		BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+		return AmazonS3ClientBuilder
+			.standard()
+			.withRegion(region)
+			.withCredentials(new AWSStaticCredentialsProvider(credentials))
+			.build();
+	}
+}

--- a/mopl-core/src/main/java/com/mopl/moplcore/global/service/S3Service.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/global/service/S3Service.java
@@ -1,0 +1,138 @@
+package com.mopl.moplcore.global.service;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+	private final AmazonS3 amazonS3;
+
+	@Value("${cloud.aws.s3.bucket}")
+	private String bucket;
+
+	private static final List<String> ALLOWED_EXTENSIONS = Arrays.asList(
+		"jpg", "jpeg", "png", "gif", "webp"
+	);
+
+	public String upload(MultipartFile file) {
+		validateFile(file);
+
+		String originalFilename = file.getOriginalFilename();
+		String extension = extractExtension(originalFilename);
+		String fileName = "contents/" + UUID.randomUUID() + "." + extension;
+
+		try {
+			ObjectMetadata metadata = new ObjectMetadata();
+			metadata.setContentType(file.getContentType());
+			metadata.setContentLength(file.getSize());
+
+			PutObjectRequest putObjectRequest = new PutObjectRequest(
+				bucket,
+				fileName,
+				file.getInputStream(),
+				metadata
+			).withCannedAcl(CannedAccessControlList.PublicRead);
+
+			amazonS3.putObject(putObjectRequest);
+
+			String fileUrl = amazonS3.getUrl(bucket, fileName).toString();
+			log.info("S3 파일 업로드 성공: {}", fileUrl);
+
+			return fileUrl;
+
+		} catch (IOException e) {
+			log.error("S3 파일 업로드 실패: {}", originalFilename, e);
+			throw new RuntimeException("파일 업로드에 실패했습니다.", e);
+		}
+	}
+
+	public void delete(String fileUrl) {
+		if (fileUrl == null || fileUrl.isEmpty()) {
+			log.warn("S3 삭제 시도: fileUrl이 null 또는 empty");
+			return;
+		}
+
+		try {
+			String fileName = extractFileNameFromUrl(fileUrl);
+			log.info("S3 파일 삭제 시도: bucket={}, fileName={}", bucket, fileName);
+
+			amazonS3.deleteObject(bucket, fileName);
+
+			log.info("S3 파일 삭제 성공: {}", fileName);
+
+		} catch (Exception e) {
+			log.error("S3 파일 삭제 실패: url={}, error={}", fileUrl, e.getMessage(), e);
+		}
+	}
+
+	private void validateFile(MultipartFile file) {
+		if (file == null || file.isEmpty()) {
+			throw new IllegalArgumentException("파일이 비어있습니다.");
+		}
+
+		String originalFilename = file.getOriginalFilename();
+		if (originalFilename == null || !originalFilename.contains(".")) {
+			throw new IllegalArgumentException("올바른 파일 형식이 아닙니다.");
+		}
+
+		String extension = extractExtension(originalFilename);
+		if (!ALLOWED_EXTENSIONS.contains(extension.toLowerCase())) {
+			throw new IllegalArgumentException(
+				"지원하지 않는 파일 형식입니다. (지원: jpg, jpeg, png, gif, webp)"
+			);
+		}
+
+		long maxSize = 10 * 1024 * 1024;
+		if (file.getSize() > maxSize) {
+			throw new IllegalArgumentException("파일 크기는 10MB를 초과할 수 없습니다.");
+		}
+	}
+
+	private String extractExtension(String filename) {
+		int lastDotIndex = filename.lastIndexOf(".");
+		if (lastDotIndex == -1) {
+			throw new IllegalArgumentException("파일 확장자가 없습니다.");
+		}
+		return filename.substring(lastDotIndex + 1);
+	}
+
+	private String extractFileNameFromUrl(String fileUrl) {
+		try {
+			log.info("URL 파싱 시도: {}", fileUrl);
+
+			URL url = new URL(fileUrl);
+			String path = url.getPath();
+
+			log.info("추출된 경로: {}", path);
+
+			if (path.startsWith("/")) {
+				path = path.substring(1);
+			}
+
+			log.info("최종 파일 key: {}", path);
+			return path;
+
+		} catch (Exception e) {
+			log.error("URL 파싱 실패: {}", fileUrl, e);
+			throw new IllegalArgumentException("잘못된 S3 URL 형식입니다: " + fileUrl, e);
+		}
+	}
+}


### PR DESCRIPTION
## PR 요약
플레이리스트 CRUD 및 구독 관리 API 구현 (커서 페이징, 검색, 정렬 지원)

## 체크리스트
- [x] 이 PR과 관련된 이슈가 있나요? (#xxx)
- [x] 기능/버그 수정 테스트 완료
- [ ] 코드 리뷰 완료

## 상세 설명

### 구현 기능
- 플레이리스트 CRUD (생성/조회/수정/삭제)
- 플레이리스트 목록 조회 (커서 페이징, 검색 필터, 정렬)
- 플레이리스트에 콘텐츠 추가/제거
- 플레이리스트 구독/구독 취소
- 소유자 권한 체크

### 기술 구현
- QueryDSL 활용한 동적 쿼리 구현
- 커서 페이징
- @Transactional 트랜잭션 관리
- JWT 기반 현재 사용자 인증

## 검증 단계

### API 테스트 (Postman)
- 모든 엔드포인트 동작 확인

### Swagger 명세 일치 확인
- 모든 엔드포인트 일치
- 응답 구조 일치 (PlaylistDto, CursorResponse)
- HTTP 상태 코드 일치

## 추가 코멘트