### PR TITLE
[WatchingSession] core-api 모듈에 콘텐츠 시청자 수 조회용 메서드 추가

### DIFF
--- a/mopl-core/src/main/java/com/mopl/moplcore/domain/watch/repository/WatchingSessionReader.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/domain/watch/repository/WatchingSessionReader.java
@@ -10,7 +10,7 @@ import lombok.RequiredArgsConstructor;
 @Component
 @RequiredArgsConstructor
 public class WatchingSessionReader {
-	private static final String CONTENT_WATCHERS_KEY_PREFIX = "watching:content:";
+	private static final String CONTENT_WATCHERS_KEY_PREFIX = "watch:content:";
 
 	private final StringRedisTemplate redisTemplate;
 

--- a/mopl-core/src/test/java/com/mopl/moplcore/WatchingSession/WatchingSessionReaderTest.java
+++ b/mopl-core/src/test/java/com/mopl/moplcore/WatchingSession/WatchingSessionReaderTest.java
@@ -1,0 +1,43 @@
+package com.mopl.moplcore.WatchingSession;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.mopl.moplcore.domain.watch.repository.WatchingSessionReader;
+
+@SpringBootTest
+@ActiveProfiles("dev")
+class WatchingSessionReaderTest {
+
+	@Autowired
+	private WatchingSessionReader reader;
+
+	@Autowired
+	private StringRedisTemplate redisTemplate;
+
+	@Test
+	void countByContentId_동작확인() {
+		// given
+		UUID contentId = UUID.randomUUID();
+		String key = "watch:content:" + contentId;
+
+		redisTemplate.opsForZSet().add(key, "user1", System.currentTimeMillis());
+		redisTemplate.opsForZSet().add(key, "user2", System.currentTimeMillis());
+
+		// when
+		long count = reader.countByContentId(contentId);
+
+		// then
+		assertThat(count).isEqualTo(2);
+
+		// cleanup
+		redisTemplate.delete(key);
+	}
+}


### PR DESCRIPTION
## PR 요약
<!-- 이번 PR의 목적과 변경 사항을 간단히 작성해주세요.-->
레디스에서 콘텐츠 시청자 수를 반환해줍니다.

## 체크리스트
- [x] 이 PR과 관련된 이슈가 있나요? (#38)
- [x] 기능/버그 수정 테스트 완료
- [ ] 코드 리뷰 완료


## 상세 설명
<!-- 변경 사항, 추가된 기능, 버그 수정 내용 등을 자세히 작성해주세요.-->
watch:content:{contentId}로 콘텐츠에 대한 시청자 세션 set의 크기를 반환해줍니다.

## 검증 단계
<!-- 
PR을 적용하기 전에 확인한 사항과 테스트 방법을 작성해주세요.
예시:
1. 로컬 서버 실행 후 API 정상 동작 확인
2. 신규 기능 UI/UX 테스트 완료
3. 기존 기능 회귀 테스트 완료
-->
로컬 레디스 + 테스트코드에서 진행

## 추가 코멘트
<!-- 팀원에게 공유할 필요가 있는 추가 정보나 주석 등을 작성해주세요.-->
