### PR TITLE
[Notification] 커서 페이지네이션 구현

### DIFF
--- a/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/domain/notification/controller/NotificationController.java
+++ b/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/domain/notification/controller/NotificationController.java
@@ -1,6 +1,5 @@
 package com.mopl.moplwebsocketsse.domain.notification.controller;
 
-import java.util.List;
 import java.util.UUID;
 
 import org.springframework.security.core.Authentication;
@@ -11,7 +10,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.mopl.moplwebsocketsse.domain.notification.dto.CursorResponseNotificationDto;
 import com.mopl.moplwebsocketsse.domain.notification.dto.NotificationDto;
+import com.mopl.moplwebsocketsse.domain.notification.dto.NotificationSortBy;
+import com.mopl.moplwebsocketsse.domain.notification.dto.NotificationSortDirection;
 import com.mopl.moplwebsocketsse.domain.notification.service.NotificationService;
 
 import lombok.RequiredArgsConstructor;
@@ -24,12 +26,19 @@ public class NotificationController {
 	private final NotificationService notificationService;
 
 	@GetMapping
-	public List<NotificationDto> list(
+	public CursorResponseNotificationDto<NotificationDto> findNotifications(
 		Authentication authentication,
-		@RequestParam(name = "unreadOnly", defaultValue = "false") boolean unreadOnly
+		@RequestParam(name = "unreadOnly", defaultValue = "false") boolean unreadOnly,
+		@RequestParam(name = "cursor", required = false) String cursor,
+		@RequestParam(name = "idAfter", required = false) UUID idAfter,
+		@RequestParam(name = "limit", defaultValue = "20") int limit,
+		@RequestParam(name = "sortBy", defaultValue = "CREATED_AT") NotificationSortBy sortBy,
+		@RequestParam(name = "sortDirection", defaultValue = "ASCENDING") NotificationSortDirection sortDirection
 	) {
 		UUID userId = (UUID)authentication.getPrincipal();
-		return notificationService.list(userId, unreadOnly);
+		return notificationService.findNotifications(
+			userId, unreadOnly, cursor, idAfter, limit, sortBy, sortDirection
+		);
 	}
 
 	@PatchMapping("/{id}/read")

--- a/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/domain/notification/dto/CursorResponseNotificationDto.java
+++ b/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/domain/notification/dto/CursorResponseNotificationDto.java
@@ -1,0 +1,15 @@
+package com.mopl.moplwebsocketsse.domain.notification.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+public record CursorResponseNotificationDto<T>(
+	List<T> data,
+	String nextCursor,
+	UUID nextIdAfter,
+	boolean hasNext,
+	long totalCount,
+	NotificationSortBy sortBy,
+	NotificationSortDirection sortDirection
+) {
+}

--- a/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/domain/notification/dto/NotificationSortBy.java
+++ b/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/domain/notification/dto/NotificationSortBy.java
@@ -1,0 +1,5 @@
+package com.mopl.moplwebsocketsse.domain.notification.dto;
+
+public enum NotificationSortBy {
+	CREATED_AT
+}

--- a/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/domain/notification/dto/NotificationSortDirection.java
+++ b/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/domain/notification/dto/NotificationSortDirection.java
@@ -1,0 +1,6 @@
+package com.mopl.moplwebsocketsse.domain.notification.dto;
+
+public enum NotificationSortDirection {
+	ASCENDING,
+	DESCENDING
+}

--- a/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/domain/notification/repository/NotificationRepository.java
+++ b/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/domain/notification/repository/NotificationRepository.java
@@ -1,15 +1,15 @@
 package com.mopl.moplwebsocketsse.domain.notification.repository;
 
-import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.mopl.moplwebsocketsse.domain.notification.entity.Notification;
 
-public interface NotificationRepository extends JpaRepository<Notification, UUID> {
+public interface NotificationRepository
+	extends JpaRepository<Notification, UUID>, NotificationRepositoryCustom {
 
-	List<Notification> findByReceiverIdOrderByCreatedAtDesc(UUID receiverId);
+	long countByReceiverId(UUID receiverId);
 
-	List<Notification> findByReceiverIdAndReadAtIsNullOrderByCreatedAtDesc(UUID receiverId);
+	long countByReceiverIdAndReadAtIsNull(UUID receiverId);
 }

--- a/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/domain/notification/repository/NotificationRepositoryCustom.java
+++ b/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/domain/notification/repository/NotificationRepositoryCustom.java
@@ -1,0 +1,21 @@
+package com.mopl.moplwebsocketsse.domain.notification.repository;
+
+import java.util.List;
+import java.util.UUID;
+
+import com.mopl.moplwebsocketsse.domain.notification.dto.NotificationSortBy;
+import com.mopl.moplwebsocketsse.domain.notification.dto.NotificationSortDirection;
+import com.mopl.moplwebsocketsse.domain.notification.entity.Notification;
+
+public interface NotificationRepositoryCustom {
+
+	List<Notification> findByReceiverIdWithCursor(
+		UUID receiverId,
+		boolean unreadOnly,
+		String cursor,
+		UUID idAfter,
+		int limit,
+		NotificationSortBy sortBy,
+		NotificationSortDirection sortDirection
+	);
+}

--- a/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/domain/notification/repository/NotificationRepositoryCustomImpl.java
+++ b/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/domain/notification/repository/NotificationRepositoryCustomImpl.java
@@ -1,0 +1,91 @@
+package com.mopl.moplwebsocketsse.domain.notification.repository;
+
+import static com.mopl.moplwebsocketsse.domain.notification.entity.QNotification.*;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.stereotype.Repository;
+
+import com.mopl.moplwebsocketsse.domain.notification.dto.NotificationSortBy;
+import com.mopl.moplwebsocketsse.domain.notification.dto.NotificationSortDirection;
+import com.mopl.moplwebsocketsse.domain.notification.entity.Notification;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationRepositoryCustomImpl implements NotificationRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public List<Notification> findByReceiverIdWithCursor(
+		UUID receiverId,
+		boolean unreadOnly,
+		String cursor,
+		UUID idAfter,
+		int limit,
+		NotificationSortBy sortBy,
+		NotificationSortDirection sortDirection
+	) {
+		return queryFactory
+			.selectFrom(notification)
+			.where(
+				receiverIdEq(receiverId),
+				unreadOnlyCondition(unreadOnly),
+				cursorCondition(cursor, idAfter, sortBy, sortDirection)
+			)
+			.orderBy(orderSpecifier(sortBy, sortDirection))
+			.limit((long)limit + 1)
+			.fetch();
+	}
+
+	private BooleanExpression receiverIdEq(UUID receiverId) {
+		return receiverId != null ? notification.receiverId.eq(receiverId) : null;
+	}
+
+	private BooleanExpression unreadOnlyCondition(boolean unreadOnly) {
+		return unreadOnly ? notification.readAt.isNull() : null;
+	}
+
+	private BooleanExpression cursorCondition(
+		String cursor,
+		UUID idAfter,
+		NotificationSortBy sortBy,
+		NotificationSortDirection sortDirection
+	) {
+		if (cursor == null || cursor.isBlank() || idAfter == null) {
+			return null;
+		}
+
+		Instant cursorTime = Instant.parse(cursor);
+		boolean isDesc = (sortDirection == NotificationSortDirection.DESCENDING);
+
+		return switch (sortBy) {
+			case CREATED_AT -> isDesc
+				? notification.createdAt.lt(cursorTime)
+				.or(notification.createdAt.eq(cursorTime).and(notification.id.lt(idAfter)))
+				: notification.createdAt.gt(cursorTime)
+				.or(notification.createdAt.eq(cursorTime).and(notification.id.gt(idAfter)));
+		};
+	}
+
+	private OrderSpecifier<?>[] orderSpecifier(
+		NotificationSortBy sortBy,
+		NotificationSortDirection sortDirection
+	) {
+		boolean isDesc = (sortDirection == NotificationSortDirection.DESCENDING);
+
+		return switch (sortBy) {
+			case CREATED_AT -> new OrderSpecifier[] {
+				isDesc ? notification.createdAt.desc() : notification.createdAt.asc(),
+				isDesc ? notification.id.desc() : notification.id.asc()
+			};
+		};
+	}
+}

--- a/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/domain/notification/service/NotificationService.java
+++ b/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/domain/notification/service/NotificationService.java
@@ -7,7 +7,10 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.mopl.moplwebsocketsse.domain.notification.dto.CursorResponseNotificationDto;
 import com.mopl.moplwebsocketsse.domain.notification.dto.NotificationDto;
+import com.mopl.moplwebsocketsse.domain.notification.dto.NotificationSortBy;
+import com.mopl.moplwebsocketsse.domain.notification.dto.NotificationSortDirection;
 import com.mopl.moplwebsocketsse.domain.notification.entity.Notification;
 import com.mopl.moplwebsocketsse.domain.notification.repository.NotificationRepository;
 
@@ -20,12 +23,54 @@ public class NotificationService {
 	private final NotificationRepository notificationRepository;
 
 	@Transactional(readOnly = true)
-	public List<NotificationDto> list(UUID me, boolean unreadOnly) {
-		List<Notification> list = unreadOnly
-			? notificationRepository.findByReceiverIdAndReadAtIsNullOrderByCreatedAtDesc(me)
-			: notificationRepository.findByReceiverIdOrderByCreatedAtDesc(me);
+	public CursorResponseNotificationDto<NotificationDto> findNotifications(
+		UUID me,
+		boolean unreadOnly,
+		String cursor,
+		UUID idAfter,
+		int limit,
+		NotificationSortBy sortBy,
+		NotificationSortDirection sortDirection
+	) {
+		if (sortBy != NotificationSortBy.CREATED_AT) {
+			throw new IllegalArgumentException("지원되지 않는 정렬 방식입니다 : " + sortBy);
+		}
+		if (sortDirection == null) {
+			throw new IllegalArgumentException("정렬 방향은 필수입니다.");
+		}
 
-		return list.stream().map(NotificationDto::from).toList();
+		int size = Math.min(Math.max(limit, 1), 100);
+
+		List<Notification> fetched = notificationRepository.findByReceiverIdWithCursor(
+			me, unreadOnly, cursor, idAfter, size, sortBy, sortDirection
+		);
+
+		boolean hasNext = fetched.size() > size;
+		List<Notification> page = hasNext ? fetched.subList(0, size) : fetched;
+
+		List<NotificationDto> data = page.stream().map(NotificationDto::from).toList();
+
+		String nextCursor = null;
+		UUID nextIdAfter = null;
+		if (hasNext && !page.isEmpty()) {
+			Notification last = page.get(page.size() - 1);
+			nextCursor = last.getCreatedAt().toString();
+			nextIdAfter = last.getId();
+		}
+
+		long totalCount = unreadOnly
+			? notificationRepository.countByReceiverIdAndReadAtIsNull(me)
+			: notificationRepository.countByReceiverId(me);
+
+		return new CursorResponseNotificationDto<>(
+			data,
+			nextCursor,
+			nextIdAfter,
+			hasNext,
+			totalCount,
+			sortBy,
+			sortDirection
+		);
 	}
 
 	@Transactional


### PR DESCRIPTION
## PR 요약
<!-- 이번 PR의 목적과 변경 사항을 간단히 작성해주세요.-->
Notification의 커서 페이지네이션을 구현하였습니다.


## 체크리스트
- [x] 이 PR과 관련된 이슈가 있나요? (#49)
- [x] 기능/버그 수정 테스트 완료
- [x] 코드 리뷰 완료


## 상세 설명
<!-- 변경 사항, 추가된 기능, 버그 수정 내용 등을 자세히 작성해주세요.-->
### NotificationController 수정
- 조회 메서드에 파라미터 추가/ENUM 사용
- List 대신 CursorResponseNotificationDto 반환하도록 변경

### NotificationService 수정
- 조회 메서드에 파라미터 추가/ENUM 사용
- 조회 메서드 커서 페이지네이션 세부 구현
- List 대신 CursorResponseNotificationDto 반환하도록 변경

### notification.dto에 파일 추가
- CursorResponseNotificationDto
- NotificationSortBy(ENUM)
- NotificationSortDirection(ENUM)

### notification.repository에 파일 추가 및 기존 repo 코드 수정
- NotificationRepositoryCustom
- NotificationRepositoryCustomImpl


## 검증 단계
<!-- 
PR을 적용하기 전에 확인한 사항과 테스트 방법을 작성해주세요.
예시:
1. 로컬 서버 실행 후 API 정상 동작 확인
2. 신규 기능 UI/UX 테스트 완료
3. 기존 기능 회귀 테스트 완료
-->
로컬 서버 실행 후 postman으로 API 동작 확인

### limit = 1 test
<img width="486" height="544" alt="Notification 커서 테스트_limit=1" src="https://github.com/user-attachments/assets/98bb616a-9ea0-4830-93d9-dba3f62ae7a8" />

### limit = 2 test
<img width="509" height="651" alt="Notification 커서 테스트_limit=2" src="https://github.com/user-attachments/assets/ab1b8f9d-3d6f-41c9-8665-0d17efdd4650" />

### limit =1 test -> nextCursor test
<img width="546" height="546" alt="Notification 커서 테스트_nextCursor" src="https://github.com/user-attachments/assets/95a4922b-edda-43f3-ad9c-ce019eca7e73" />


## 추가 코멘트
<!-- 팀원에게 공유할 필요가 있는 추가 정보나 주석 등을 작성해주세요.-->
