### PR TITLE
[DM] 생성 및 저장, 브로드캐스트 구현

### DIFF
--- a/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/domain/directMessage/controller/DirectMessageController.java
+++ b/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/domain/directMessage/controller/DirectMessageController.java
@@ -1,0 +1,36 @@
+package com.mopl.moplwebsocketsse.domain.directMessage.controller;
+
+import java.util.UUID;
+
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+
+import com.mopl.moplwebsocketsse.domain.directMessage.dto.DirectMessageSendRequest;
+import com.mopl.moplwebsocketsse.domain.directMessage.service.DirectMessageService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class DirectMessageController {
+
+	private final DirectMessageService directMessageService;
+
+	@MessageMapping("/conversations/{conversationId}/direct-messages")
+	public void sendMessage(
+		@DestinationVariable UUID conversationId,
+		DirectMessageSendRequest request,
+		Authentication authentication
+	) {
+		UUID senderId = (UUID)authentication.getPrincipal();
+
+		log.debug("[DirectMessageController] Message received. conversationId={}, senderId={}",
+			conversationId, senderId);
+
+		directMessageService.sendMessage(conversationId, senderId, request.content());
+	}
+}

--- a/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/domain/directMessage/dto/DirectMessageSendRequest.java
+++ b/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/domain/directMessage/dto/DirectMessageSendRequest.java
@@ -1,6 +1,8 @@
 package com.mopl.moplwebsocketsse.domain.directMessage.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record DirectMessageSendRequest(
-	String content
+	@NotBlank String content
 ) {
 }

--- a/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/domain/directMessage/repository/ConversationParticipantsRepository.java
+++ b/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/domain/directMessage/repository/ConversationParticipantsRepository.java
@@ -21,6 +21,13 @@ public interface ConversationParticipantsRepository extends JpaRepository<Conver
 	@Query("""
     SELECT cp FROM ConversationParticipants cp
     JOIN FETCH cp.user
+    WHERE cp.conversation.id = :conversationId
+    """)
+	List<ConversationParticipants> findByConversationIdWithUser(UUID conversationId);
+
+	@Query("""
+    SELECT cp FROM ConversationParticipants cp
+    JOIN FETCH cp.user
     WHERE cp.conversation.id IN :conversationIds
     """)
 	List<ConversationParticipants> findByConversationIdInWithUser(List<UUID> conversationIds);

--- a/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/domain/directMessage/service/DirectMessageService.java
+++ b/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/domain/directMessage/service/DirectMessageService.java
@@ -1,0 +1,87 @@
+package com.mopl.moplwebsocketsse.domain.directMessage.service;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.mopl.moplwebsocketsse.domain.directMessage.dto.DirectMessageDto;
+import com.mopl.moplwebsocketsse.domain.directMessage.entity.Conversation;
+import com.mopl.moplwebsocketsse.domain.directMessage.entity.ConversationParticipants;
+import com.mopl.moplwebsocketsse.domain.directMessage.entity.DirectMessage;
+import com.mopl.moplwebsocketsse.domain.directMessage.exception.ConversationNotFoundException;
+import com.mopl.moplwebsocketsse.domain.directMessage.exception.NotConversationParticipantException;
+import com.mopl.moplwebsocketsse.domain.directMessage.mapper.ConversationMapper;
+import com.mopl.moplwebsocketsse.domain.directMessage.repository.ConversationParticipantsRepository;
+import com.mopl.moplwebsocketsse.domain.directMessage.repository.ConversationRepository;
+import com.mopl.moplwebsocketsse.domain.directMessage.repository.DirectMessageRepository;
+import com.mopl.moplwebsocketsse.domain.user.dto.UserSummary;
+import com.mopl.moplwebsocketsse.domain.user.entity.User;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DirectMessageService {
+
+	private static final String DM_DEST_PREFIX = "/sub/conversations/";
+	private static final String DM_DEST_SUFFIX = "/direct-messages";
+
+	private final DirectMessageRepository directMessageRepository;
+	private final ConversationRepository conversationRepository;
+	private final ConversationParticipantsRepository participantsRepository;
+	private final ConversationMapper conversationMapper;
+	private final SimpMessagingTemplate messagingTemplate;
+
+	@Transactional
+	public DirectMessageDto sendMessage(UUID conversationId, UUID senderId, String content) {
+		Conversation conversation = conversationRepository.findById(conversationId)
+			.orElseThrow(ConversationNotFoundException::new);
+
+		List<ConversationParticipants> participants =
+			participantsRepository.findByConversationIdWithUser(conversationId);
+
+		User sender = null;
+		User receiver = null;
+
+		for (ConversationParticipants cp : participants) {
+			if (cp.getUser().getId().equals(senderId)) {
+				sender = cp.getUser();
+			} else {
+				receiver = cp.getUser();
+			}
+		}
+
+		if (sender == null) {
+			throw new NotConversationParticipantException();
+		}
+
+		if (receiver == null) {
+			throw new IllegalStateException("Receiver not found in conversation: " + conversationId);
+		}
+
+		DirectMessage directMessage = new DirectMessage(conversation, sender, content);
+		directMessageRepository.save(directMessage);
+
+		conversation.updateLastMessage(directMessage);
+
+		DirectMessageDto dto = conversationMapper.toDirectMessageDto(
+			directMessage,
+			new UserSummary(sender.getId(), sender.getName(), sender.getProfileImageUrl()),
+			new UserSummary(receiver.getId(), receiver.getName(), receiver.getProfileImageUrl())
+		);
+
+		// 브로드캐스트
+		String destination = DM_DEST_PREFIX + conversationId + DM_DEST_SUFFIX;
+		messagingTemplate.convertAndSend(destination, dto);
+
+		log.debug("[DirectMessageService] Message sent. conversationId={}, senderId={}, receiverId={}",
+			conversationId, senderId, receiver.getId());
+
+		return dto;
+	}
+}


### PR DESCRIPTION
## PR 요약
<!-- 이번 PR의 목적과 변경 사항을 간단히 작성해주세요.-->
생성 및 저장, 브로드캐스트 구현

## 체크리스트
- [x] 이 PR과 관련된 이슈가 있나요? (#47)
- [x] 기능/버그 수정 테스트 완료
- [ ] 코드 리뷰 완료


## 상세 설명
<!-- 변경 사항, 추가된 기능, 버그 수정 내용 등을 자세히 작성해주세요.-->
클라이언트로 부터 SEND /pub/conversations/{conversationId}/direct-messages로 DM대화가 수신되면
컨트롤러에서 Authentication에 있는 senderId 추출해서 서비스 계층을 호출하고
대화방이 존재하는 지 체크하고
참여자 조회한 뒤
DM 엔티티 생성 및 DB 저장
대화 LastMesage 업데이트
dto 생성해서 WebSocket으로 브로드캐스트 했습니다.

## 검증 단계
<!-- 
PR을 적용하기 전에 확인한 사항과 테스트 방법을 작성해주세요.
예시:
1. 로컬 서버 실행 후 API 정상 동작 확인
2. 신규 기능 UI/UX 테스트 완료
3. 기존 기능 회귀 테스트 완료
-->
로컬 서버에서 테스트 이후 DB 저장 확인 + 웹소켓에 전달되는지 확인, 브라우저에서 프론트가 대화를 그려주는지 확인

## 추가 코멘트
<!-- 팀원에게 공유할 필요가 있는 추가 정보나 주석 등을 작성해주세요.-->
security 설정이 변경 되면 Authentication 에서 그냥 uuid를 가져올 수 없어서 변경 필요