### PR TITLE
[Notification] 컨트롤러 메서드 수정 및 unreadOnly 제거 작업

### DIFF
--- a/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/domain/notification/controller/NotificationController.java
+++ b/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/domain/notification/controller/NotificationController.java
@@ -3,8 +3,8 @@ package com.mopl.moplwebsocketsse.domain.notification.controller;
 import java.util.UUID;
 
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -28,22 +28,21 @@ public class NotificationController {
 	@GetMapping
 	public CursorResponseNotificationDto<NotificationDto> findNotifications(
 		Authentication authentication,
-		@RequestParam(name = "unreadOnly", defaultValue = "false") boolean unreadOnly,
 		@RequestParam(name = "cursor", required = false) String cursor,
 		@RequestParam(name = "idAfter", required = false) UUID idAfter,
 		@RequestParam(name = "limit", defaultValue = "20") int limit,
-		@RequestParam(name = "sortBy", defaultValue = "CREATED_AT") NotificationSortBy sortBy,
+		@RequestParam(name = "sortBy", defaultValue = "createdAt") NotificationSortBy sortBy,
 		@RequestParam(name = "sortDirection", defaultValue = "ASCENDING") NotificationSortDirection sortDirection
 	) {
 		UUID userId = (UUID)authentication.getPrincipal();
 		return notificationService.findNotifications(
-			userId, unreadOnly, cursor, idAfter, limit, sortBy, sortDirection
+			userId, cursor, idAfter, limit, sortBy, sortDirection
 		);
 	}
 
-	@PatchMapping("/{id}/read")
-	public NotificationDto markAsRead(Authentication authentication, @PathVariable("id") UUID id) {
+	@DeleteMapping("/{notificationId}")
+	public void deleteNotification(Authentication authentication, @PathVariable("notificationId") UUID id) {
 		UUID userId = (UUID)authentication.getPrincipal();
-		return notificationService.markAsRead(userId, id);
+		notificationService.deleteNotification(userId, id);
 	}
 }

--- a/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/domain/notification/dto/NotificationSortBy.java
+++ b/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/domain/notification/dto/NotificationSortBy.java
@@ -1,5 +1,5 @@
 package com.mopl.moplwebsocketsse.domain.notification.dto;
 
 public enum NotificationSortBy {
-	CREATED_AT
+	createdAt
 }

--- a/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/domain/notification/entity/Notification.java
+++ b/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/domain/notification/entity/Notification.java
@@ -33,6 +33,7 @@ public class Notification extends BaseEntity {
 	@Column(nullable = false)
 	private NotificationLevel level;
 
+	// ERD에 존재하지만 필요성에 의문이 드는 항목
 	@Column(name = "read_at")
 	private Instant readAt;
 
@@ -44,6 +45,7 @@ public class Notification extends BaseEntity {
 		this.readAt = null;
 	}
 
+	// readAt이 필요 없어 삭제 결정되면 하단 메서드들은 모두 삭제
 	public boolean isRead() {
 		return readAt != null;
 	}

--- a/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/domain/notification/repository/NotificationRepository.java
+++ b/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/domain/notification/repository/NotificationRepository.java
@@ -11,5 +11,5 @@ public interface NotificationRepository
 
 	long countByReceiverId(UUID receiverId);
 
-	long countByReceiverIdAndReadAtIsNull(UUID receiverId);
+	long deleteByIdAndReceiverId(UUID receiverId, UUID id);
 }

--- a/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/domain/notification/repository/NotificationRepositoryCustom.java
+++ b/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/domain/notification/repository/NotificationRepositoryCustom.java
@@ -11,7 +11,6 @@ public interface NotificationRepositoryCustom {
 
 	List<Notification> findByReceiverIdWithCursor(
 		UUID receiverId,
-		boolean unreadOnly,
 		String cursor,
 		UUID idAfter,
 		int limit,

--- a/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/domain/notification/repository/NotificationRepositoryCustomImpl.java
+++ b/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/domain/notification/repository/NotificationRepositoryCustomImpl.java
@@ -26,7 +26,6 @@ public class NotificationRepositoryCustomImpl implements NotificationRepositoryC
 	@Override
 	public List<Notification> findByReceiverIdWithCursor(
 		UUID receiverId,
-		boolean unreadOnly,
 		String cursor,
 		UUID idAfter,
 		int limit,
@@ -37,7 +36,6 @@ public class NotificationRepositoryCustomImpl implements NotificationRepositoryC
 			.selectFrom(notification)
 			.where(
 				receiverIdEq(receiverId),
-				unreadOnlyCondition(unreadOnly),
 				cursorCondition(cursor, idAfter, sortBy, sortDirection)
 			)
 			.orderBy(orderSpecifier(sortBy, sortDirection))
@@ -46,11 +44,10 @@ public class NotificationRepositoryCustomImpl implements NotificationRepositoryC
 	}
 
 	private BooleanExpression receiverIdEq(UUID receiverId) {
-		return receiverId != null ? notification.receiverId.eq(receiverId) : null;
-	}
-
-	private BooleanExpression unreadOnlyCondition(boolean unreadOnly) {
-		return unreadOnly ? notification.readAt.isNull() : null;
+		if (receiverId == null) {
+			throw new IllegalArgumentException("receiverId is null");
+		}
+		return notification.receiverId.eq(receiverId);
 	}
 
 	private BooleanExpression cursorCondition(
@@ -67,7 +64,7 @@ public class NotificationRepositoryCustomImpl implements NotificationRepositoryC
 		boolean isDesc = (sortDirection == NotificationSortDirection.DESCENDING);
 
 		return switch (sortBy) {
-			case CREATED_AT -> isDesc
+			case createdAt -> isDesc
 				? notification.createdAt.lt(cursorTime)
 				.or(notification.createdAt.eq(cursorTime).and(notification.id.lt(idAfter)))
 				: notification.createdAt.gt(cursorTime)
@@ -82,7 +79,7 @@ public class NotificationRepositoryCustomImpl implements NotificationRepositoryC
 		boolean isDesc = (sortDirection == NotificationSortDirection.DESCENDING);
 
 		return switch (sortBy) {
-			case CREATED_AT -> new OrderSpecifier[] {
+			case createdAt -> new OrderSpecifier[] {
 				isDesc ? notification.createdAt.desc() : notification.createdAt.asc(),
 				isDesc ? notification.id.desc() : notification.id.asc()
 			};

--- a/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/domain/notification/service/NotificationService.java
+++ b/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/domain/notification/service/NotificationService.java
@@ -25,14 +25,16 @@ public class NotificationService {
 	@Transactional(readOnly = true)
 	public CursorResponseNotificationDto<NotificationDto> findNotifications(
 		UUID me,
-		boolean unreadOnly,
 		String cursor,
 		UUID idAfter,
 		int limit,
 		NotificationSortBy sortBy,
 		NotificationSortDirection sortDirection
 	) {
-		if (sortBy != NotificationSortBy.CREATED_AT) {
+		if (me == null) {
+			throw new AccessDeniedException("사용자 ID가 없어 접근이 거부되었습니다. : " + me);
+		}
+		if (sortBy != NotificationSortBy.createdAt) {
 			throw new IllegalArgumentException("지원되지 않는 정렬 방식입니다 : " + sortBy);
 		}
 		if (sortDirection == null) {
@@ -42,7 +44,7 @@ public class NotificationService {
 		int size = Math.min(Math.max(limit, 1), 100);
 
 		List<Notification> fetched = notificationRepository.findByReceiverIdWithCursor(
-			me, unreadOnly, cursor, idAfter, size, sortBy, sortDirection
+			me, cursor, idAfter, size, sortBy, sortDirection
 		);
 
 		boolean hasNext = fetched.size() > size;
@@ -58,9 +60,7 @@ public class NotificationService {
 			nextIdAfter = last.getId();
 		}
 
-		long totalCount = unreadOnly
-			? notificationRepository.countByReceiverIdAndReadAtIsNull(me)
-			: notificationRepository.countByReceiverId(me);
+		long totalCount = notificationRepository.countByReceiverId(me);
 
 		return new CursorResponseNotificationDto<>(
 			data,
@@ -74,16 +74,16 @@ public class NotificationService {
 	}
 
 	@Transactional
-	public NotificationDto markAsRead(UUID me, UUID notificationId) {
-		Notification notification = notificationRepository.findById(notificationId)
-			.orElseThrow(() -> new IllegalArgumentException("Notification not found : " + notificationId));
-
-		if (!notification.getReceiverId().equals(me)) {
-			throw new AccessDeniedException("You are not allowed to read this notification : " + notificationId);
+	public void deleteNotification(UUID me, UUID notificationId) {
+		if (me == null) {
+			throw new AccessDeniedException("사용자 ID가 존재하지 않아 접근이 거부되었습니다.");
 		}
 
-		notification.markAsRead();
-		return NotificationDto.from(notification);
+		long deleted = notificationRepository.deleteByIdAndReceiverId(notificationId, me);
+
+		if (deleted == 0) {
+			throw new IllegalArgumentException("Notification not found : " + notificationId);
+		}
 	}
 
 	@Transactional


### PR DESCRIPTION
## PR 요약
<!-- 이번 PR의 목적과 변경 사항을 간단히 작성해주세요.-->
컨트롤러 메서드 수정 및 unreadOnly 파라미터와 관련 코드 제거

## 체크리스트
- [x] 이 PR과 관련된 이슈가 있나요? (#52)
- [x] 기능/버그 수정 테스트 완료
- [x] 코드 리뷰 완료


## 상세 설명
<!-- 변경 사항, 추가된 기능, 버그 수정 내용 등을 자세히 작성해주세요.-->
- 컨트롤러 GET 조회 메서드에서 unreadOnly(읽음 처리) 파라미터 제거
- 컨트롤러 읽음 처리 메서드가 PATCH -> DELETE로 변경
- unreadOnly를 활용하던 repo, service 관련 코드 수정
- 쿼리에서 receiverId가 null로 들어와 전체 조회가 될 수 있던 문제 해결
: 서비스 및 impl에 null 검증 추가

## 검증 단계
<!-- 
PR을 적용하기 전에 확인한 사항과 테스트 방법을 작성해주세요.
예시:
1. 로컬 서버 실행 후 API 정상 동작 확인
2. 신규 기능 UI/UX 테스트 완료
3. 기존 기능 회귀 테스트 완료
-->


## 추가 코멘트
<!-- 팀원에게 공유할 필요가 있는 추가 정보나 주석 등을 작성해주세요.-->
ERD Cloud의 알림 테이블에 read_at이 있는데, 알림 처리 과정에서 읽으면 삭제하기 때문에 이 컬럼 및 관련 엔티티 메서드가 필요할 지 의문입니다. 당장 사용처는 없는 상황입니다. 하단은 readAt 관련 엔티티 메서드 두 가지입니다.

public boolean isRead() {
	return readAt != null;
}

public void markAsRead() {
	if (this.readAt == null) {
		this.readAt = Instant.now();
	}
}
