### PR TITLE
add: Redis 기반 임시 비밀번호 저장 Registry 추가

### DIFF
--- a/mopl-core/src/main/java/com/mopl/moplcore/domain/user/registry/InMemoryUserRegistry.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/domain/user/registry/InMemoryUserRegistry.java
@@ -10,8 +10,8 @@ import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
 
-// 레디스 대용
-@Profile({"dev", "local"})
+@Deprecated
+@Profile("none")
 @Component
 @RequiredArgsConstructor
 public class InMemoryUserRegistry implements UserRegistry {

--- a/mopl-core/src/main/java/com/mopl/moplcore/domain/user/registry/RedisUserRegistry.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/domain/user/registry/RedisUserRegistry.java
@@ -1,0 +1,54 @@
+package com.mopl.moplcore.domain.user.registry;
+
+import java.time.Duration;
+import java.util.UUID;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class RedisUserRegistry implements UserRegistry {
+
+	private final RedisTemplate<String, String> redisTemplate;
+	private final PasswordEncoder passwordEncoder;
+
+	private static final String KEY_PREFIX = "temp:password:";
+	private static final Duration TTL = Duration.ofMinutes(3);
+
+	@Override
+	public String setTempPassword(UUID userId) {
+		String originPassword = UUID.randomUUID().toString().substring(0, 8);
+		String encodedPassword = passwordEncoder.encode(originPassword);
+
+		String key = getKey(userId);
+		redisTemplate.opsForValue().set(key, encodedPassword, TTL);
+
+		return originPassword;
+	}
+
+	@Override
+	public String getEncodedPassword(UUID userId) {
+		String key = getKey(userId);
+		return redisTemplate.opsForValue().get(key);
+	}
+
+	@Override
+	public boolean existById(UUID userId) {
+		String key = getKey(userId);
+		return redisTemplate.hasKey(key);
+	}
+
+	@Override
+	public void removeTempPassword(UUID userId) {
+		String key = getKey(userId);
+		redisTemplate.delete(key);
+	}
+
+	private String getKey(UUID userId) {
+		return KEY_PREFIX + userId.toString();
+	}
+}


### PR DESCRIPTION
- 기존 InMemoryUserRegistry 제거
- Redis 기반 임시 비밀번호 저장 로직 도입

## PR 요약
임시 비밀번호 저장 방식을 InMemory 방식에서 Redis 기반으로 변경했습니다.  
이를 통해 멀티 인스턴스 환경에서도 일관된 임시 비밀번호 검증이 가능하도록 개선했습니다.

## 체크리스트
- [x] 이 PR과 관련된 이슈가 있나요? (#69 )
- [x] 기능/버그 수정 테스트 완료
- [ ] 코드 리뷰 완료

## 상세 설명
- 기존 InMemoryUserRegistry는 단일 인스턴스 환경에서만 정상 동작하여 확장성에 한계가 있었습니다.
- RedisUserRegistry를 신규 추가하여 임시 비밀번호를 Redis에 저장하도록 변경했습니다.
- 임시 비밀번호는 `temp:password:{userId}` 형태의 key로 저장되며, TTL은 3분으로 설정했습니다.
- 비밀번호는 평문 저장이 아닌 PasswordEncoder를 통해 암호화된 값만 Redis에 저장합니다.
- 기존 InMemoryUserRegistry는 @Deprecated 처리 및 비활성 Profile(`none`)로 설정했습니다.

## 검증 단계
1. 로컬 환경에서 Redis 실행 후 임시 비밀번호 발급 API 호출
2. Redis에 key 및 TTL 정상 저장 여부 확인
3. 임시 비밀번호 검증 로직 정상 동작 확인
4. TTL 만료 후 자동 삭제 확인

