### PR TITLE
[Content] Elasticsearch NativeQuery 기반 커서 페이징 구현

### DIFF
--- a/mopl-core/src/main/java/com/mopl/moplcore/domain/content/config/ContentSyncRunner.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/domain/content/config/ContentSyncRunner.java
@@ -1,0 +1,27 @@
+package com.mopl.moplcore.domain.content.config;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import com.mopl.moplcore.domain.content.service.ContentSyncService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ContentSyncRunner implements CommandLineRunner {
+
+    private final ContentSyncService contentSyncService;
+
+    @Override
+    public void run(String... args) {
+        log.info("Content 자동 동기화 시작");
+        try {contentSyncService.syncAllContents();
+            log.info("Content 자동 동기화 완료");
+        } catch (Exception e) {
+            log.error("Content 자동 동기화 실패", e);
+        }
+    }
+}

--- a/mopl-core/src/main/java/com/mopl/moplcore/domain/content/converter/StringToTypeConverter.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/domain/content/converter/StringToTypeConverter.java
@@ -1,0 +1,28 @@
+package com.mopl.moplcore.domain.content.converter;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+import com.mopl.moplcore.domain.content.entity.Type;
+
+@Component
+public class StringToTypeConverter implements Converter<String, Type> {
+	@Override
+	public Type convert(String source) {
+		if (source == null || source.isBlank()) return null;
+		try {
+			String normalized = source
+				.replaceAll("([a-z])([A-Z])", "$1_$2")
+				.replace("-", "_")
+				.toUpperCase();
+
+			if (normalized.equals("SPORT") || normalized.equals("SPORTS")) {
+				return Type.SPORTS;
+			}
+
+			return Type.valueOf(normalized);
+		} catch (IllegalArgumentException e) {
+			return null;
+		}
+	}
+}

--- a/mopl-core/src/main/java/com/mopl/moplcore/domain/content/document/ContentDocument.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/domain/content/document/ContentDocument.java
@@ -34,6 +34,9 @@ public class ContentDocument {
 	private String id;
 
 	@Field(type = FieldType.Keyword)
+	private String contentId;
+
+	@Field(type = FieldType.Keyword)
 	private Type type;
 
 	@Field(type = FieldType.Text, analyzer = "nori")
@@ -58,28 +61,26 @@ public class ContentDocument {
 	private Long watcherCount;
 
 	@Field(type = FieldType.Date)
-	private LocalDate createdAt;
+	private Instant createdAt;
 
 	@Field(type = FieldType.Date)
-	private LocalDate updatedAt;
+	private Instant updatedAt;
 
 	public static ContentDocument from(UUID id, Type type, String title, String description, String thumbnailUrl,
 		List<String> tags, Double averageRating, Integer reviewCount, Long watcherCount, Instant createdAt) {
-		LocalDate createdAtLocal =
-			createdAt != null ? LocalDate.ofInstant(createdAt, ZoneId.systemDefault()) : LocalDate.now();
 
 		return ContentDocument.builder()
 			.id(id.toString())
+			.contentId(id.toString())
 			.type(type)
 			.title(title)
 			.description(description)
 			.thumbnailUrl(thumbnailUrl)
-			.tags(tags != null ? tags : List.of())
-			.averageRating(averageRating != null ? averageRating : 0.0)
-			.reviewCount(reviewCount != null ? reviewCount : 0)
-			.watcherCount(watcherCount != null ? watcherCount : 0L)
-			.createdAt(createdAtLocal)
-			.updatedAt(createdAtLocal)
+			.tags(tags)
+			.averageRating(averageRating)
+			.reviewCount(reviewCount)
+			.watcherCount(watcherCount)
+			.createdAt(createdAt != null ? createdAt : Instant.now())
 			.build();
 	}
 }

--- a/mopl-core/src/main/java/com/mopl/moplcore/domain/content/dto/CursorResponseContentDto.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/domain/content/dto/CursorResponseContentDto.java
@@ -9,7 +9,9 @@ import java.util.UUID;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Getter
 @Builder
 public class CursorResponseContentDto {
@@ -22,24 +24,36 @@ public class CursorResponseContentDto {
 	private String sortBy;
 	private String sortDirection;
 
-	public record Cursor(UUID id, Instant createdAt) {}
+	public record Cursor(
+		UUID id,
+		Instant createdAt,
+		Double averageRating,
+		Long watcherCount
+	) {
+	}
 
-	public static String encodeCursor(UUID id, Instant createdAt) {
-		String raw = id.toString() + "|" + createdAt.toString();
+	public static String encodeCursor(Cursor cursor) {
+		String raw = cursor.id() + "|" + cursor.createdAt() + "|" +
+			(cursor.averageRating() != null ? cursor.averageRating() : "") + "|" +
+			(cursor.watcherCount() != null ? cursor.watcherCount() : "");
+
 		return Base64.getUrlEncoder()
-			.withoutPadding()
 			.encodeToString(raw.getBytes(StandardCharsets.UTF_8));
 	}
 
-	public static Cursor decodeCursor(String cursor) {
+	public static Cursor decodeCursor(String cursorStr) {
 		try {
-			String decoded = new String(
-				Base64.getUrlDecoder().decode(cursor), StandardCharsets.UTF_8
+			String decoded = new String(Base64.getUrlDecoder().decode(cursorStr), StandardCharsets.UTF_8);
+			String[] parts = decoded.split("\\|", -1);
+			return new Cursor(
+				UUID.fromString(parts[0]),
+				Instant.parse(parts[1]),
+				parts[2].isEmpty() ? null : Double.parseDouble(parts[2]),
+				parts[3].isEmpty() ? null : Long.parseLong(parts[3])
 			);
-			String[] parts = decoded.split("\\|");
-			return new Cursor(UUID.fromString(parts[0]), Instant.parse(parts[1]));
 		} catch (Exception e) {
-			throw new IllegalArgumentException("유효하지 않은 커서 형식", e);
+			log.error("Cursor decoding failed: {}", cursorStr);
+			throw new IllegalArgumentException("Invalid cursor format");
 		}
 	}
 }

--- a/mopl-core/src/main/java/com/mopl/moplcore/domain/content/repository/ContentRepositoryImpl.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/domain/content/repository/ContentRepositoryImpl.java
@@ -1,5 +1,7 @@
 package com.mopl.moplcore.domain.content.repository;
 
+import static com.mopl.moplcore.domain.content.dto.ContentSearchRequest.SortDirection.*;
+
 import java.util.List;
 
 import com.mopl.moplcore.domain.content.dto.ContentSearchRequest;
@@ -84,12 +86,22 @@ public class ContentRepositoryImpl implements ContentRepositoryCustom {
 				CursorResponseContentDto.decodeCursor(request.getCursor());
 
 			boolean isAsc = request.getSortDirection() ==
-				ContentSearchRequest.SortDirection.ASCENDING;
+				ASCENDING;
 
 			if (request.getSortBy() == ContentSearchRequest.SortBy.createdAt) {
-				return isAsc
-					? content.createdAt.gt(cursor.createdAt())
-					: content.createdAt.lt(cursor.createdAt());
+				if (isAsc) {
+					return content.createdAt.gt(cursor.createdAt())
+						.or(
+							content.createdAt.eq(cursor.createdAt())
+								.and(content.id.gt(cursor.id()))
+						);
+				} else {
+					return content.createdAt.lt(cursor.createdAt())
+						.or(
+							content.createdAt.eq(cursor.createdAt())
+								.and(content.id.lt(cursor.id()))
+						);
+				}
 			}
 
 			return null;
@@ -98,15 +110,25 @@ public class ContentRepositoryImpl implements ContentRepositoryCustom {
 		}
 	}
 
-	private OrderSpecifier<?> getOrderSpecifier(ContentSearchRequest request) {
+	private OrderSpecifier<?>[] getOrderSpecifier(ContentSearchRequest request) {
 		QContent content = QContent.content;
-
-		boolean isAsc = request.getSortDirection() == ContentSearchRequest.SortDirection.ASCENDING;
+		boolean isAsc = request.getSortDirection() == ASCENDING;
 
 		return switch (request.getSortBy()) {
-			case createdAt -> isAsc ? content.createdAt.asc() : content.createdAt.desc();
-			case watcherCount -> throw new UnsupportedOperationException("watcherCount 정렬은 아직 미구현");
-			case rate -> isAsc ? content.averageRating.asc() : content.averageRating.desc();
+			case createdAt -> isAsc
+				? new OrderSpecifier<?>[] {
+				content.createdAt.asc(),
+				content.id.asc()
+			}
+				: new OrderSpecifier<?>[] {
+				content.createdAt.desc(),
+				content.id.desc()
+			};
+			case watcherCount -> null; // ES / Redis 기준
+			case rate -> new OrderSpecifier<?>[] {
+				isAsc ? content.averageRating.asc() : content.averageRating.desc(),
+				content.id.asc()
+			};
 		};
 	}
 

--- a/mopl-core/src/main/java/com/mopl/moplcore/domain/content/service/ContentSearchService.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/domain/content/service/ContentSearchService.java
@@ -1,19 +1,23 @@
 package com.mopl.moplcore.domain.content.service;
 
-import java.time.Instant;
-import java.time.ZoneId;
-import java.util.ArrayList;
+// 핵심: 신버전용 NativeQuery (elc 패키지 확인!)
 import java.util.List;
 import java.util.UUID;
 
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
+import org.springframework.data.elasticsearch.client.elc.NativeQuery;
+
+// Elasticsearch Client (쿼리 빌더용)
+import co.elastic.clients.elasticsearch._types.FieldValue;
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.json.JsonData;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+// Spring Data Core 관련
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.data.elasticsearch.core.SearchHits;
-import org.springframework.data.elasticsearch.core.query.Criteria;
-import org.springframework.data.elasticsearch.core.query.CriteriaQuery;
-import org.springframework.data.elasticsearch.core.query.Query;
 import org.springframework.stereotype.Service;
 
 import com.mopl.moplcore.domain.content.document.ContentDocument;
@@ -24,11 +28,7 @@ import com.mopl.moplcore.domain.content.entity.Content;
 import com.mopl.moplcore.domain.content.entity.Type;
 import com.mopl.moplcore.domain.content.exception.ContentNotFoundException;
 import com.mopl.moplcore.domain.content.repository.ContentRepository;
-import com.mopl.moplcore.domain.content.repository.ContentSearchRepository;
 import com.mopl.moplcore.domain.watch.repository.WatchingSessionReader;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Service
@@ -37,145 +37,233 @@ public class ContentSearchService {
 
 	private static final String TMDB_IMAGE_BASE_URL = "https://image.tmdb.org/t/p/w500";
 
-	private final ContentSearchRepository contentSearchRepository;
 	private final ContentRepository contentRepository;
 	private final ElasticsearchOperations elasticsearchOperations;
 	private final WatchingSessionReader watchingSessionReader;
 	private final WatcherCountSyncService watcherCountSyncService;
 
 	public CursorResponseContentDto searchContents(ContentSearchRequest request) {
-
 		if (request.getSortBy() == ContentSearchRequest.SortBy.watcherCount) {
 			watcherCountSyncService.syncWatcherCountsAsync();
 		}
 
-		Criteria criteria = buildCriteria(request);
+		BoolQuery.Builder mainBoolQuery = buildBoolQuery(request);
 
-		Sort sort = buildSort(request);
+		var queryBuilder = NativeQuery.builder()
+			.withQuery(q -> q.bool(mainBoolQuery.build()))
+			.withMaxResults(request.getLimit() + 1);
 
-		Query query = new CriteriaQuery(criteria).setPageable(PageRequest.of(0, request.getLimit() + 1, sort));
-		SearchHits<ContentDocument> searchHits = elasticsearchOperations.search(query, ContentDocument.class);
+		boolean isAsc = request.getSortDirection() == ContentSearchRequest.SortDirection.ASCENDING;
+		SortOrder order = isAsc ? SortOrder.Asc : SortOrder.Desc;
 
-		List<ContentDocument> documents = searchHits.getSearchHits().stream().map(SearchHit::getContent).toList();
+		switch (request.getSortBy()) {
+			case createdAt -> queryBuilder.withSort(s -> s.field(f -> f.field("createdAt").order(order)));
+			case rate -> {
+				queryBuilder.withSort(s -> s.field(f -> f.field("averageRating").order(order)));
+				queryBuilder.withSort(s -> s.field(f -> f.field("createdAt").order(SortOrder.Desc)));
+			}
+			case watcherCount -> {
+				queryBuilder.withSort(s -> s.field(f -> f.field("watcherCount").order(order)));
+				queryBuilder.withSort(s -> s.field(f -> f.field("createdAt").order(SortOrder.Desc)));
+			}
+		}
 
-		long totalCount = elasticsearchOperations.count(new CriteriaQuery(criteria), ContentDocument.class);
+		SearchHits<ContentDocument> searchHits = elasticsearchOperations.search(
+			queryBuilder.build(), ContentDocument.class);
+
+		List<ContentDocument> documents = searchHits.getSearchHits()
+			.stream().map(SearchHit::getContent).toList();
+
+		long totalCount = elasticsearchOperations.count(
+			NativeQuery.builder().withQuery(q -> q.bool(buildBasicFilters(request).build())).build(),
+			ContentDocument.class
+		);
 
 		boolean hasNext = documents.size() > request.getLimit();
-		if (hasNext) {
-			documents = documents.subList(0, request.getLimit());
-		}
+		if (hasNext) documents = documents.subList(0, request.getLimit());
 
 		List<ContentDto> contentDtos = documents.stream().map(this::toDto).toList();
-
-		String nextCursor = null;
-		if (hasNext && !documents.isEmpty()) {
-			ContentDocument lastDoc = documents.get(documents.size() - 1);
-			Instant instant = lastDoc.getCreatedAt().atStartOfDay(ZoneId.systemDefault()).toInstant();
-			nextCursor = CursorResponseContentDto.encodeCursor(UUID.fromString(lastDoc.getId()), instant);
-		}
+		String nextCursor = generateNextCursor(documents, hasNext, request);
 
 		return CursorResponseContentDto.builder()
-			.data(contentDtos)
-			.nextCursor(nextCursor)
-			.nextIdAfter(
-				hasNext && !documents.isEmpty() ? UUID.fromString(documents.get(documents.size() - 1).getId()) : null)
-			.hasNext(hasNext)
-			.totalCount((int)totalCount)
-			.sortBy(request.getSortBy().name())
-			.sortDirection(request.getSortDirection().name())
-			.build();
+			.data(contentDtos).nextCursor(nextCursor).hasNext(hasNext)
+			.totalCount(totalCount).sortBy(request.getSortBy().name())
+			.sortDirection(request.getSortDirection().name()).build();
 	}
 
-	public ContentDto getContent(UUID id) {
-		Content content = contentRepository.findById(id).orElseThrow(() -> new ContentNotFoundException(id));
-
-		return toDto(content);
-	}
-
-	private Criteria buildCriteria(ContentSearchRequest request) {
-		List<Criteria> criteriaList = new ArrayList<>();
-
-		if (request.getKeywordLike() != null && !request.getKeywordLike().trim().isEmpty()) {
-			Criteria titleCriteria = Criteria.where("title").matches(request.getKeywordLike());
-			Criteria descCriteria = Criteria.where("description").matches(request.getKeywordLike());
-			criteriaList.add(titleCriteria.or(descCriteria));
-		}
-
-		if (request.getTypeEqual() != null) {
-			criteriaList.add(Criteria.where("type").is(request.getTypeEqual()));
-		}
-
-		if (request.getTagsIn() != null && !request.getTagsIn().isEmpty()) {
-			criteriaList.add(Criteria.where("tags").in(request.getTagsIn()));
-		}
+	private BoolQuery.Builder buildBoolQuery(ContentSearchRequest request) {
+		BoolQuery.Builder boolQuery = buildBasicFilters(request);
 
 		if (request.getCursor() != null && !request.getCursor().isBlank()) {
 			try {
 				CursorResponseContentDto.Cursor cursor = CursorResponseContentDto.decodeCursor(request.getCursor());
-
-				java.time.LocalDate cursorDate = java.time.LocalDate.ofInstant(cursor.createdAt(),
-					ZoneId.systemDefault());
-
 				boolean isAsc = request.getSortDirection() == ContentSearchRequest.SortDirection.ASCENDING;
 
-				if (request.getSortBy() == ContentSearchRequest.SortBy.createdAt) {
-					if (isAsc) {
-						criteriaList.add(Criteria.where("createdAt").greaterThan(cursorDate));
-					} else {
-						criteriaList.add(Criteria.where("createdAt").lessThan(cursorDate));
-					}
+				switch (request.getSortBy()) {
+					case createdAt -> addCreatedAtCursor(boolQuery, cursor, isAsc);
+					case rate -> addRateCursor(boolQuery, cursor, isAsc);
+					case watcherCount -> addWatcherCountCursor(boolQuery, cursor, isAsc);
 				}
-			} catch (IllegalArgumentException e) {
-				log.warn("Invalid cursor: {}", request.getCursor());
+			} catch (Exception e) {
+				log.error("Cursor decoding error", e);
 			}
 		}
-
-		if (criteriaList.isEmpty()) {
-			return new Criteria();
-		}
-
-		Criteria result = criteriaList.get(0);
-		for (int i = 1; i < criteriaList.size(); i++) {
-			result = result.and(criteriaList.get(i));
-		}
-
-		return result;
+		return boolQuery;
 	}
 
-	private Sort buildSort(ContentSearchRequest request) {
-		boolean isAsc = request.getSortDirection() == ContentSearchRequest.SortDirection.ASCENDING;
-		Sort.Direction direction = isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;
+	private BoolQuery.Builder buildBasicFilters(ContentSearchRequest request) {
+		BoolQuery.Builder boolQuery = new BoolQuery.Builder();
 
-		return switch (request.getSortBy()) {
-			case createdAt -> Sort.by(direction, "createdAt");
-			case rate -> Sort.by(direction, "averageRating");
-			case watcherCount -> Sort.by(direction, "watcherCount");
-		};
+		if (request.getKeywordLike() != null && !request.getKeywordLike().trim().isEmpty()) {
+			String keyword = request.getKeywordLike();
+			boolQuery.must(m -> m.bool(b -> b
+				.should(s -> s.match(mt -> mt.field("title").query(keyword)))
+				.should(s -> s.match(mt -> mt.field("description").query(keyword)))
+				.minimumShouldMatch("1")
+			));
+		}
+
+		if (request.getTypeEqual() != null) {
+			boolQuery.filter(f -> f.term(t -> t.field("type").value(request.getTypeEqual().name())));
+		}
+
+		if (request.getTagsIn() != null && !request.getTagsIn().isEmpty()) {
+			List<FieldValue> tags = request.getTagsIn().stream().map(FieldValue::of).toList();
+			boolQuery.filter(f -> f.terms(t -> t.field("tags").terms(ts -> ts.value(tags))));
+		}
+
+		return boolQuery;
+	}
+
+	private void addCreatedAtCursor(
+		BoolQuery.Builder boolQuery,
+		CursorResponseContentDto.Cursor cursor,
+		boolean isAsc
+	) {
+		String createdAt = cursor.createdAt().toString();
+
+		boolQuery.filter(f -> f.range(r -> r.date(d -> {
+			d.field("createdAt");
+			if (isAsc) {
+				d.gt(createdAt);
+			} else {
+				d.lt(createdAt);
+			}
+			return d;
+		})));
+	}
+	private void addRateCursor(
+		BoolQuery.Builder boolQuery,
+		CursorResponseContentDto.Cursor cursor,
+		boolean isAsc
+	) {
+		Double rate = cursor.averageRating() != null ? cursor.averageRating() : 0.0;
+		String createdAt = cursor.createdAt().toString();
+
+		boolQuery.filter(f -> f.bool(b -> b.minimumShouldMatch("1")
+
+			.should(s -> s.range(r -> r.number(n -> {
+				n.field("averageRating");
+				if (isAsc) {
+					n.gt(rate);
+				} else {
+					n.lt(rate);
+				}
+				return n;
+			})))
+
+			.should(s -> s.bool(sb -> sb
+				.must(m -> m.term(t -> t.field("averageRating").value(rate)))
+				.must(m -> m.range(r -> r.date(d -> {
+					d.field("createdAt");
+					if (isAsc) {
+						d.gt(createdAt);
+					} else {
+						d.lt(createdAt);
+					}
+					return d;
+				})))
+			))
+		));
+	}
+
+
+	private void addWatcherCountCursor(
+		BoolQuery.Builder boolQuery,
+		CursorResponseContentDto.Cursor cursor,
+		boolean isAsc
+	) {
+		Double count = cursor.watcherCount() != null
+			? cursor.watcherCount().doubleValue()
+			: 0.0;
+		String createdAt = cursor.createdAt().toString();
+
+		boolQuery.filter(f -> f.bool(b -> b.minimumShouldMatch("1")
+
+			.should(s -> s.range(r -> r.number(n -> {
+				n.field("watcherCount");
+				if (isAsc) {
+					n.gt(count);
+				} else {
+					n.lt(count);
+				}
+				return n;
+			})))
+
+			.should(s -> s.bool(sb -> sb
+				.must(m -> m.term(t -> t.field("watcherCount").value(count)))
+				.must(m -> m.range(r -> r.date(d -> {
+					d.field("createdAt");
+					if (isAsc) {
+						d.gt(createdAt);
+					} else {
+						d.lt(createdAt);
+					}
+					return d;
+				})))
+			))
+		));
+	}
+
+	private String generateNextCursor(List<ContentDocument> docs, boolean hasNext, ContentSearchRequest request) {
+		if (!hasNext || docs.isEmpty()) return null;
+		ContentDocument last = docs.get(docs.size() - 1);
+
+		var cursor = new CursorResponseContentDto.Cursor(
+			UUID.fromString(last.getContentId()),
+			last.getCreatedAt(),
+			request.getSortBy() == ContentSearchRequest.SortBy.rate ? last.getAverageRating() : null,
+			request.getSortBy() == ContentSearchRequest.SortBy.watcherCount ? last.getWatcherCount() : null
+		);
+		return CursorResponseContentDto.encodeCursor(cursor);
 	}
 
 	private ContentDto toDto(ContentDocument document) {
-		String fullThumbnailUrl = buildImageUrl(document.getType(), document.getThumbnailUrl());
-
-		UUID contentId = UUID.fromString(document.getId());
-		long watcherCount = watchingSessionReader.countByContentId(contentId);
-
 		return ContentDto.builder()
-			.id(UUID.fromString(document.getId()))
+			.id(UUID.fromString(document.getContentId()))
 			.type(document.getType())
 			.title(document.getTitle())
 			.description(document.getDescription())
-			.thumbnailUrl(fullThumbnailUrl)
+			.thumbnailUrl(buildImageUrl(document.getType(), document.getThumbnailUrl()))
 			.tags(document.getTags() != null ? document.getTags() : List.of())
 			.averageRating(document.getAverageRating() != null ? document.getAverageRating() : 0.0)
 			.reviewCount(document.getReviewCount() != null ? document.getReviewCount() : 0)
-			.watcherCount(watcherCount)
+			.watcherCount(watchingSessionReader.countByContentId(UUID.fromString(document.getContentId())))
 			.build();
 	}
 
+	private String buildImageUrl(Type type, String path) {
+		if (path == null) return null;
+		if (path.startsWith("http")) return path;
+		return (type == Type.MOVIE || type == Type.TV_SERIES) ? TMDB_IMAGE_BASE_URL + path : path;
+	}
+
+	public ContentDto getContent(UUID id) {
+		Content content = contentRepository.findById(id).orElseThrow(() -> new ContentNotFoundException(id));
+		return toDto(content);
+	}
+
 	private ContentDto toDto(Content content) {
-
-		long watcherCount = watchingSessionReader.countByContentId(content.getId());
-
 		return ContentDto.builder()
 			.id(content.getId())
 			.type(content.getType())
@@ -185,22 +273,7 @@ public class ContentSearchService {
 			.tags(List.of())
 			.averageRating(content.getAverageRating())
 			.reviewCount(content.getReviewCount())
-			.watcherCount(watcherCount)
+			.watcherCount(watchingSessionReader.countByContentId(content.getId()))
 			.build();
-	}
-
-	private String buildImageUrl(Type type, String path) {
-		if (path == null) {
-			return null;
-		}
-
-		if (path.startsWith("http://") || path.startsWith("https://")) {
-			return path;
-		}
-
-		return switch (type) {
-			case MOVIE, TV_SERIES -> TMDB_IMAGE_BASE_URL + path;
-			case SPORTS -> path;
-		};
 	}
 }

--- a/mopl-core/src/main/java/com/mopl/moplcore/domain/content/service/ContentSyncService.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/domain/content/service/ContentSyncService.java
@@ -77,9 +77,19 @@ public class ContentSyncService {
 			.map(ct -> ct.getTag().getName())
 			.collect(Collectors.toList());
 
-		return ContentDocument.from(content.getId(), content.getType(), content.getTitle(), content.getDescription(),
-			content.getThumbnailUrl(), tags, content.getAverageRating(), content.getReviewCount(), 0L,
-			content.getCreatedAt());
+		return ContentDocument.builder()
+			.id(content.getId().toString())
+			.contentId(content.getId().toString())
+			.type(content.getType())
+			.title(content.getTitle())
+			.description(content.getDescription())
+			.thumbnailUrl(content.getThumbnailUrl())
+			.tags(tags)
+			.averageRating(content.getAverageRating())
+			.reviewCount(content.getReviewCount())
+			.watcherCount(0L)
+			.createdAt(content.getCreatedAt())
+			.build();
 	}
 
 	public void updateWatcherCount(UUID contentId) {


### PR DESCRIPTION
## PR 요약
Elasticsearch 콘텐츠 검색 API 500 에러 해결 - NativeQuery 기반 커서 페이징 구현

## 체크리스트
- [x] 이 PR과 관련된 이슈가 있나요? (#76)
- [x] 기능/버그 수정 테스트 완료
- [ ] 코드 리뷰 완료

## 상세 설명
**문제:**
- CriteriaQuery의 OR 조건 생성 실패로 500 에러 발생
- watcherCount/rate 정렬 시 커서 페이징 작동 안 함

**해결:**
- CriteriaQuery → NativeQuery 전환
- BoolQuery + RangeQuery + TermQuery 조합으로 커서 조건 구현
- `(sortField < cursor) OR (sortField = cursor AND createdAt < cursor.createdAt)` 로직 적용
- ContentDocument에 contentId 필드 추가

**주요 변경:**
- ContentSearchService: buildBoolQuery(), addCreatedAtCursor(), addRateCursor(), addWatcherCountCursor() 구현
- ContentDocument: contentId 필드 추가 (Keyword 타입)
- ContentSyncService: contentId 동기화 로직 추가

## 검증 단계
1. Docker 재빌드 후 Elasticsearch 동기화 확인
2. Postman 테스트: 커서 페이징 정상 동작 확인
3. 프론트엔드 무한 스크롤 테스트 완료
4. 페이징 검증 (watcherCount=0 엣지 케이스 포함)

## 추가 코멘트