### PR TITLE
[Security] WS-SSE 모듈에서 redis에서 활성 토큰으로 인증 로직 추가

### DIFF
--- a/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/security/filter/JwtAuthenticationFilter.java
+++ b/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/security/filter/JwtAuthenticationFilter.java
@@ -12,6 +12,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import com.mopl.moplwebsocketsse.security.config.SecurityPaths;
 import com.mopl.moplwebsocketsse.security.exception.InValidAccessTokenException;
 import com.mopl.moplwebsocketsse.security.jwt.JwtTokenProvider;
+import com.mopl.moplwebsocketsse.security.jwt.registry.JwtRegistry;
 import com.mopl.moplwebsocketsse.security.principal.MoplUserDetails;
 
 import jakarta.servlet.FilterChain;
@@ -31,6 +32,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 	private final JwtTokenProvider tokenProvider;
 	private final UserDetailsService userDetailsService;
+	private final JwtRegistry jwtRegistry;
 
 	@Override
 	protected boolean shouldNotFilter(HttpServletRequest request) {
@@ -53,6 +55,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 		if (!tokenProvider.validateAccessToken(accessToken))
 			throw new InValidAccessTokenException();
+
+		if (!jwtRegistry.hasActiveJwtInformationByAccessToken(accessToken)) {
+			throw new InValidAccessTokenException();
+		}
 
 		String email = tokenProvider.getSubject(accessToken);
 		MoplUserDetails userDetails = (MoplUserDetails)userDetailsService.loadUserByUsername(email);

--- a/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/security/jwt/JwtChannelInterceptor.java
+++ b/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/security/jwt/JwtChannelInterceptor.java
@@ -14,6 +14,8 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 
 import com.mopl.moplwebsocketsse.domain.user.entity.Role;
+import com.mopl.moplwebsocketsse.security.exception.InValidAccessTokenException;
+import com.mopl.moplwebsocketsse.security.jwt.registry.JwtRegistry;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 public class JwtChannelInterceptor implements ChannelInterceptor {
 
 	private final JwtTokenProvider jwtTokenProvider;
+	private final JwtRegistry jwtRegistry;
 
 	@Override
 	public Message<?> preSend(Message<?> message, MessageChannel channel) {
@@ -41,14 +44,18 @@ public class JwtChannelInterceptor implements ChannelInterceptor {
 
 			if (!jwtTokenProvider.validateAccessToken(token)) {
 				log.warn("WebSocket 연결 실패: 유효하지 않은 JWT 토큰");
-				throw new IllegalArgumentException("Invalid JWT token");
+				throw new InValidAccessTokenException();
 			}
+
+			if (!jwtRegistry.hasActiveJwtInformationByAccessToken(token))
+				throw new InValidAccessTokenException();
 
 			UUID userId = jwtTokenProvider.getUserId(token);
 			Role role = jwtTokenProvider.getRole(token);
 
 			List<SimpleGrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_" + role.name()));
-			UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userId, null, authorities);
+			UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userId, null,
+				authorities);
 
 			accessor.setUser(authentication);
 

--- a/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/security/jwt/registry/JwtRegistry.java
+++ b/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/security/jwt/registry/JwtRegistry.java
@@ -1,0 +1,5 @@
+package com.mopl.moplwebsocketsse.security.jwt.registry;
+
+public interface JwtRegistry {
+	boolean hasActiveJwtInformationByAccessToken(String accessToken);
+}

--- a/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/security/jwt/registry/RedisJwtRegistry.java
+++ b/mopl-websocket-sse/src/main/java/com/mopl/moplwebsocketsse/security/jwt/registry/RedisJwtRegistry.java
@@ -1,0 +1,20 @@
+package com.mopl.moplwebsocketsse.security.jwt.registry;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class RedisJwtRegistry implements JwtRegistry {
+
+	private static final String ACCESS_PREFIX = "jwt:access:";
+
+	private final StringRedisTemplate stringRedisTemplate;
+
+	@Override
+	public boolean hasActiveJwtInformationByAccessToken(String accessToken) {
+		return stringRedisTemplate.hasKey(ACCESS_PREFIX + accessToken);
+	}
+}


### PR DESCRIPTION
## PR 요약
<!-- 이번 PR의 목적과 변경 사항을 간단히 작성해주세요.-->
WS-SSE 모듈에서 redis에서 활성 토큰으로 인증 로직 추가

## 체크리스트
- [x] 이 PR과 관련된 이슈가 있나요? (#87)
- [ ] 기능/버그 수정 테스트 완료
- [ ] 코드 리뷰 완료


## 상세 설명
<!-- 변경 사항, 추가된 기능, 버그 수정 내용 등을 자세히 작성해주세요.-->
Core 모듈에서 인증하는 방식이 레디스의 활성 토큰 까지 검증해서 core 모듈에서 코드들을 가져와서 사용함
일단 레디스에서 활성 토큰만 검증하면 되기 때문에 활성 토큰 유효성 검사하는 부분만 가져왔습니다

## 검증 단계
<!-- 
PR을 적용하기 전에 확인한 사항과 테스트 방법을 작성해주세요.
예시:
1. 로컬 서버 실행 후 API 정상 동작 확인
2. 신규 기능 UI/UX 테스트 완료
3. 기존 기능 회귀 테스트 완료
-->


## 추가 코멘트
<!-- 팀원에게 공유할 필요가 있는 추가 정보나 주석 등을 작성해주세요.-->
토큰이 만료되는 경우
jwt:access: 의 레디스 값이 지워져도 로그아웃 되어서 로그인 페이지로 리다이렉트 되지 못하고 에러 500만 내는걸 확인했고
또 웹소켓 연결은 유지되는데 로그아웃되는 걸 확인해야 웹소켓을 닫거나 할 것 같습니다.
이부분은 프론트엔드 코드도 좀 살펴봐야할 것 같네요 