### PR TITLE
[Content] watcherCount 정렬 시 커서 페이징 미작동 문제 해결

### DIFF
--- a/mopl-core/src/main/java/com/mopl/moplcore/domain/content/service/ContentSyncService.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/domain/content/service/ContentSyncService.java
@@ -80,6 +80,8 @@ public class ContentSyncService {
 	}
 
 	private ContentDocument convertToDocumentManual(Content content, List<String> tags) {
+		long watcherCount = watchingSessionReader.countByContentId(content.getId());
+
 		return ContentDocument.builder()
 			.id(content.getId().toString())
 			.contentId(content.getId().toString())
@@ -90,6 +92,7 @@ public class ContentSyncService {
 			.tags(tags)
 			.averageRating(content.getAverageRating())
 			.reviewCount(content.getReviewCount())
+			.watcherCount(watcherCount)
 			.createdAt(content.getCreatedAt())
 			.build();
 	}
@@ -127,6 +130,8 @@ public class ContentSyncService {
 			.map(ct -> ct.getTag().getName())
 			.collect(Collectors.toList());
 
+		long watcherCount = watchingSessionReader.countByContentId(content.getId());
+
 		return ContentDocument.builder()
 			.id(content.getId().toString())
 			.contentId(content.getId().toString())
@@ -137,7 +142,7 @@ public class ContentSyncService {
 			.tags(tags)
 			.averageRating(content.getAverageRating())
 			.reviewCount(content.getReviewCount())
-			.watcherCount(0L)
+			.watcherCount(watcherCount)
 			.createdAt(content.getCreatedAt())
 			.build();
 	}


### PR DESCRIPTION
## PR 요약
watcherCount 정렬 시 커서 페이징이 작동하지 않던 문제를 해결했습니다. Elasticsearch 동기화 시 watcherCount를 실시간으로 계산하여 저장하도록 수정했습니다.

## 체크리스트
- [x] 이 PR과 관련된 이슈가 있나요? (#102)
- [x] 기능/버그 수정 테스트 완료
- [ ] 코드 리뷰 완료

## 상세 설명
### 문제
- watcherCount로 정렬 시 첫 페이지만 조회되고 다음 페이지가 빈 결과로 반환됨
- Elasticsearch 인덱스의 watcherCount가 모두 0으로 저장되어 커서 필터가 정상 작동하지 않음

### 해결
- `ContentSyncService`의 `convertToDocument()`, `convertToDocumentManual()` 메서드 수정
- `watchingSessionReader`를 통해 실시간 시청자 수를 계산하여 ES에 저장
- 동기화 시점에 정확한 watcherCount 값이 인덱싱되도록 개선

### 변경 파일
- `ContentSyncService.java`

## 검증 단계
1. 로컬 환경에서 전체 콘텐츠 동기화 실행
2. watcherCount DESCENDING 정렬로 검색 API 호출
3. 연속 조회 테스트
4. Elasticsearch 인덱스에 watcherCount 값이 올바르게 저장되었는지 확인
5. 결과: 모든 페이지 정상 조회 확인

## 추가 코멘트