### PR TITLE
[Playlist] 구독자순 정렬 및 커서 페이지네이션 구현

### DIFF
--- a/mopl-core/src/main/java/com/mopl/moplcore/domain/playlist/repository/PlaylistRepositoryImpl.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/domain/playlist/repository/PlaylistRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.mopl.moplcore.domain.playlist.repository;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
@@ -11,6 +12,7 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.querydsl.core.types.Order;
 
 import lombok.RequiredArgsConstructor;
 
@@ -29,9 +31,13 @@ public class PlaylistRepositoryImpl implements PlaylistRepositoryCustom {
 			.where(
 				keywordLike(request.getKeywordLike()),
 				ownerIdEqual(request.getOwnerIdEqual()),
-				subscriberIdEqual(request.getSubscriberIdEqual())
+				subscriberIdEqual(request.getSubscriberIdEqual()),
+				cursorCondition(request)
 			)
-			.orderBy(getOrderSpecifier(request))
+			.orderBy(
+				getOrderSpecifier(request),
+				playlist.id.asc()  // 동점 처리
+			)
 			.limit(request.getLimit() + 1)
 			.fetch();
 	}
@@ -83,14 +89,102 @@ public class PlaylistRepositoryImpl implements PlaylistRepositoryCustom {
 		);
 	}
 
+	private BooleanExpression cursorCondition(PlaylistSearchRequest request) {
+		String cursor = request.getCursor();
+		UUID idAfter = request.getIdAfter();
+
+		if (cursor == null && idAfter == null) {
+			return null;
+		}
+
+		QPlaylist playlist = QPlaylist.playlist;
+		QPlaylistSubscription subscription = QPlaylistSubscription.playlistSubscription;
+		boolean isAsc = request.getSortDirection() == PlaylistSearchRequest.SortDirection.ASCENDING;
+
+		return switch (request.getSortBy()) {
+			case updatedAt -> {
+				if (cursor != null) {
+					CursorData data = decodeCursor(cursor);
+					Instant cursorUpdatedAt = Instant.parse(data.value);
+
+					if (isAsc) {
+						yield playlist.updatedAt.gt(cursorUpdatedAt)
+							.or(playlist.updatedAt.eq(cursorUpdatedAt)
+								.and(playlist.id.gt(data.id)));
+					} else {
+						yield playlist.updatedAt.lt(cursorUpdatedAt)
+							.or(playlist.updatedAt.eq(cursorUpdatedAt)
+								.and(playlist.id.gt(data.id)));
+					}
+				} else if (idAfter != null) {
+					yield playlist.id.gt(idAfter);
+				}
+				yield null;
+			}
+			case subscribeCount -> {
+				if (cursor != null) {
+					CursorData data = decodeCursor(cursor);
+					Long cursorSubscribeCount = Long.parseLong(data.value);
+
+					var subscribeCountExpr = JPAExpressions
+						.select(subscription.count())
+						.from(subscription)
+						.where(subscription.playlist.id.eq(playlist.id));
+
+					if (isAsc) {
+						yield subscribeCountExpr.gt(cursorSubscribeCount)
+							.or(subscribeCountExpr.eq(cursorSubscribeCount)
+								.and(playlist.id.gt(data.id)));
+					} else {
+						yield subscribeCountExpr.lt(cursorSubscribeCount)
+							.or(subscribeCountExpr.eq(cursorSubscribeCount)
+								.and(playlist.id.gt(data.id)));
+					}
+				} else if (idAfter != null) {
+					yield playlist.id.gt(idAfter);
+				}
+				yield null;
+			}
+		};
+	}
+
 	private OrderSpecifier<?> getOrderSpecifier(PlaylistSearchRequest request) {
 		QPlaylist playlist = QPlaylist.playlist;
+		QPlaylistSubscription subscription = QPlaylistSubscription.playlistSubscription;
 
 		boolean isAsc = request.getSortDirection() == PlaylistSearchRequest.SortDirection.ASCENDING;
 
 		return switch (request.getSortBy()) {
 			case updatedAt -> isAsc ? playlist.updatedAt.asc() : playlist.updatedAt.desc();
-			case subscribeCount -> throw new UnsupportedOperationException("subscribeCount 정렬은 아직 미구현");
+			case subscribeCount -> {
+				var subscribeCountExpr = JPAExpressions
+					.select(subscription.count())
+					.from(subscription)
+					.where(subscription.playlist.id.eq(playlist.id));
+
+				yield new OrderSpecifier<>(
+					isAsc ? Order.ASC : Order.DESC,
+					subscribeCountExpr
+				);
+			}
 		};
 	}
+
+	private CursorData decodeCursor(String cursor) {
+		try {
+			byte[] decoded = java.util.Base64.getUrlDecoder().decode(cursor);
+			String raw = new String(decoded, java.nio.charset.StandardCharsets.UTF_8);
+			String[] parts = raw.split("\\|");
+
+			if (parts.length != 2) {
+				throw new IllegalArgumentException("Invalid cursor format");
+			}
+
+			return new CursorData(UUID.fromString(parts[0]), parts[1]);
+		} catch (Exception e) {
+			throw new IllegalArgumentException("Invalid cursor: " + cursor, e);
+		}
+	}
+
+	private record CursorData(UUID id, String value) {}
 }

--- a/mopl-core/src/main/java/com/mopl/moplcore/domain/playlist/service/PlaylistService.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/domain/playlist/service/PlaylistService.java
@@ -83,7 +83,18 @@ public class PlaylistService {
 		String nextCursor = null;
 		if (hasNext && !playlists.isEmpty()) {
 			Playlist lastPlaylist = playlists.get(playlists.size() - 1);
-			nextCursor = encodeCursor(lastPlaylist.getId(), lastPlaylist.getUpdatedAt());
+			PlaylistDto lastDto = playlistDtos.get(playlistDtos.size() - 1);
+
+			nextCursor = switch (request.getSortBy()) {
+				case updatedAt -> encodeCursor(
+					lastPlaylist.getId(),
+					lastPlaylist.getUpdatedAt().toString()
+				);
+				case subscribeCount -> encodeCursor(
+					lastPlaylist.getId(),
+					lastDto.subscriberCount().toString()
+				);
+			};
 		}
 
 		return CursorResponsePlaylistDto.builder()
@@ -260,8 +271,8 @@ public class PlaylistService {
 		};
 	}
 
-	private String encodeCursor(UUID id, Instant updatedAt) {
-		String raw = id.toString() + "|" + updatedAt.toString();
+	private String encodeCursor(UUID id, String value) {
+		String raw = id.toString() + "|" + value;
 		return java.util.Base64.getUrlEncoder()
 			.withoutPadding()
 			.encodeToString(raw.getBytes(java.nio.charset.StandardCharsets.UTF_8));


### PR DESCRIPTION
## PR 요약
플레이리스트 구독자순 정렬 및 커서 페이지네이션 구현

## 체크리스트
- [x] 이 PR과 관련된 이슈가 있나요? (#110)
- [x] 기능/버그 수정 테스트 완료
- [ ] 코드 리뷰 완료

## 상세 설명
### 구현 내용
- 플레이리스트 구독자순(subscribeCount) 정렬 기능 추가
- updatedAt/subscribeCount 정렬 모두 커서 페이지네이션 지원
- QueryDSL 서브쿼리를 통한 구독자 수 기반 정렬 구현

### 주요 변경 파일
- `PlaylistRepositoryImpl`: 
  - `getOrderSpecifier()`: subscribeCount 케이스 구현
  - `cursorCondition()`: 정렬 기준별 커서 조건 처리
  - `decodeCursor()`: 커서 디코딩 로직 추가
- `PlaylistService`:
  - `encodeCursor()`: 범용 커서 인코딩 (String value 파라미터로 변경)
  - `searchPlaylists()`: 정렬 기준별 커서 생성 분기 처리

## 검증 단계
1. 구독자순 내림차순 정렬 테스트
   - `GET /api/playlists?sortBy=subscribeCount&sortDirection=DESCENDING&limit=10`
2. 커서 페이지네이션 연속 조회 테스트
   - nextCursor를 사용한 2페이지, 3페이지 조회 확인
3. 기존 updatedAt 정렬 정상 동작 확인 

## 추가 코멘트
- 동점 처리를 위해 playlist.id로 2차 정렬 적용