### PR TITLE
[Content] tmdb, sport에 따라 db의 url를 전처리하지 않고 바로 프론트에 반환되도록 수정

### DIFF
--- a/mopl-core/src/main/java/com/mopl/moplcore/domain/content/service/ContentManagementService.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/domain/content/service/ContentManagementService.java
@@ -28,8 +28,6 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class ContentManagementService {
 
-	private static final String TMDB_IMAGE_BASE_URL = "https://image.tmdb.org/t/p/w500";
-
 	private final ContentRepository contentRepository;
 	private final ContentTagRepository contentTagRepository;
 	private final TagRepository tagRepository;
@@ -170,34 +168,17 @@ public class ContentManagementService {
 			.map(ct -> ct.getTag().getName())
 			.toList();
 
-		String fullThumbnailUrl = buildImageUrl(content.getType(), content.getThumbnailUrl());
-
 		return ContentDto.builder()
 			.id(content.getId())
 			.type(content.getType())
 			.title(content.getTitle())
 			.description(content.getDescription())
-			.thumbnailUrl(fullThumbnailUrl)
+			.thumbnailUrl(content.getThumbnailUrl())
 			.tags(tags)
 			.averageRating(content.getAverageRating())
 			.reviewCount(content.getReviewCount())
 			.watcherCount(0)
 			.build();
-	}
-
-	private String buildImageUrl(Type type, String path) {
-		if (path == null) {
-			return null;
-		}
-
-		if (path.startsWith("http://") || path.startsWith("https://")) {
-			return path;
-		}
-
-		return switch (type) {
-			case MOVIE, TV_SERIES -> TMDB_IMAGE_BASE_URL + path;
-			case SPORTS -> path;
-		};
 	}
 
 	private boolean isS3Url(String url) {

--- a/mopl-core/src/main/java/com/mopl/moplcore/domain/content/service/ContentSearchService.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/domain/content/service/ContentSearchService.java
@@ -34,8 +34,6 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class ContentSearchService {
 
-	private static final String TMDB_IMAGE_BASE_URL = "https://image.tmdb.org/t/p/w500";
-
 	private final ContentRepository contentRepository;
 	private final ContentTagRepository contentTagRepository;
 	private final ElasticsearchOperations elasticsearchOperations;
@@ -237,13 +235,6 @@ public class ContentSearchService {
 		return CursorResponseContentDto.encodeCursor(cursor);
 	}
 
-	private String buildImageUrl(Type type, String path) {
-		if (path == null)
-			return null;
-		if (path.startsWith("http"))
-			return path;
-		return (type == Type.MOVIE || type == Type.TV_SERIES) ? TMDB_IMAGE_BASE_URL + path : path;
-	}
 
 	public ContentDto getContent(UUID id) {
 		Content content = contentRepository.findById(id).orElseThrow(() -> new ContentNotFoundException(id));
@@ -256,7 +247,7 @@ public class ContentSearchService {
 			.type(document.getType())
 			.title(document.getTitle())
 			.description(document.getDescription())
-			.thumbnailUrl(buildImageUrl(document.getType(), document.getThumbnailUrl()))
+			.thumbnailUrl(document.getThumbnailUrl())
 			.tags(document.getTags() != null ? document.getTags() : List.of())
 			.averageRating(document.getAverageRating() != null ? document.getAverageRating() : 0.0)
 			.reviewCount(document.getReviewCount() != null ? document.getReviewCount() : 0)
@@ -275,7 +266,7 @@ public class ContentSearchService {
 			.type(content.getType())
 			.title(content.getTitle())
 			.description(content.getDescription())
-			.thumbnailUrl(buildImageUrl(content.getType(), content.getThumbnailUrl()))
+			.thumbnailUrl(content.getThumbnailUrl())
 			.tags(tags)
 			.averageRating(content.getAverageRating())
 			.reviewCount(content.getReviewCount())
@@ -290,7 +281,7 @@ public class ContentSearchService {
 			.type(document.getType())
 			.title(document.getTitle())
 			.description(document.getDescription())
-			.thumbnailUrl(buildImageUrl(document.getType(), document.getThumbnailUrl()))
+			.thumbnailUrl(document.getThumbnailUrl())
 			.tags(document.getTags() != null ? document.getTags() : List.of())
 			.averageRating(document.getAverageRating() != null ? document.getAverageRating() : 0.0)
 			.reviewCount(document.getReviewCount() != null ? document.getReviewCount() : 0)


### PR DESCRIPTION
## PR 요약
S3를 사용하여 컨텐츠를 저장함에 따라. Content에서도 바로 url 전처리 없이 프론트에 반환되도록 수정 


## 체크리스트
- [x] 이 PR과 관련된 이슈가 있나요? (#114 )
- [x] 기능/버그 수정 테스트 완료
- [ ] 코드 리뷰 완료


## 상세 설명
기존에는 Content Type에 따라 url를 다르게 처리하였는데 이를 제거 후 바로 프론트에 전달하도록 수정 

## 검증 단계
로컬에서 컨테이너를 전부 띄운 후 s3에서 잘 가져옴을 확인 
<img width="1913" height="933" alt="image" src="https://github.com/user-attachments/assets/e74cc8ed-10b3-4c8d-90a1-c77344b423ab" />

