### PR TITLE
[Content] 콘텐츠 조회 시 시청자수 동기화 버그 수정

### DIFF
--- a/mopl-core/src/main/java/com/mopl/moplcore/domain/content/service/WatcherCountSyncService.java
+++ b/mopl-core/src/main/java/com/mopl/moplcore/domain/content/service/WatcherCountSyncService.java
@@ -1,21 +1,36 @@
 package com.mopl.moplcore.domain.content.service;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.elasticsearch.client.elc.NativeQuery;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.SearchHitsIterator;
 import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
-import java.util.UUID;
+import com.mopl.moplcore.domain.content.document.ContentDocument;
+import com.mopl.moplcore.domain.content.repository.ContentSearchRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class WatcherCountSyncService {
 
-    private final StringRedisTemplate redisTemplate;
-    private final ContentSyncService contentSyncService;
+	private static final String CONTENT_WATCHERS_KEY_PREFIX = "watch:content:";
+
+	private final StringRedisTemplate redisTemplate;
+	private final ContentSyncService contentSyncService;
+	private final ElasticsearchOperations elasticsearchOperations;
+	private final ContentSearchRepository contentSearchRepository;
 
     @Async("taskExecutor")
     public void syncWatcherCountsAsync() {
@@ -40,6 +55,48 @@ public class WatcherCountSyncService {
             }
         }
 
-        log.debug("watcherCount 비동기 동기화 완료: {} 건", syncCount);
-    }
+		int cleanupCount = cleanupStaleWatcherCounts();
+
+		log.debug("watcherCount 비동기 동기화 완료: 활성 {}건, 정리 {}건", syncCount, cleanupCount);
+	}
+
+	private int cleanupStaleWatcherCounts() {
+		NativeQuery query = NativeQuery.builder()
+			.withQuery(q -> q.range(r -> r.number(n -> n.field("watcherCount").gt(0.0))))
+			.withMaxResults(500)
+			.build();
+
+		int cleanupCount = 0;
+		List<ContentDocument> toUpdate = new ArrayList<>();
+
+		try (SearchHitsIterator<ContentDocument> iterator = elasticsearchOperations.searchForStream(query,
+			ContentDocument.class)) {
+			while (iterator.hasNext()) {
+				ContentDocument doc = iterator.next().getContent();
+				String key = CONTENT_WATCHERS_KEY_PREFIX + doc.getContentId();
+				Boolean exists = redisTemplate.hasKey(key);
+
+				if (Boolean.FALSE.equals(exists)) {
+					doc.setWatcherCount(0L);
+					toUpdate.add(doc);
+					cleanupCount++;
+
+					if (toUpdate.size() >= 500) {
+						contentSearchRepository.saveAll(toUpdate);
+						toUpdate.clear();
+					}
+				}
+			}
+		}
+
+		if (!toUpdate.isEmpty()) {
+			contentSearchRepository.saveAll(toUpdate);
+		}
+
+		if (cleanupCount > 0) {
+			log.debug("stale watcherCount 정리: {}건", cleanupCount);
+		}
+
+		return cleanupCount;
+	}
 }


### PR DESCRIPTION
## PR 요약
<!-- 이번 PR의 목적과 변경 사항을 간단히 작성해주세요.-->


## 체크리스트
- [x] 이 PR과 관련된 이슈가 있나요? (#126)
- [x] 기능/버그 수정 테스트 완료
- [ ] 코드 리뷰 완료


## 상세 설명
<!-- 변경 사항, 추가된 기능, 버그 수정 내용 등을 자세히 작성해주세요.-->
- content에서 시청자수가 1->0으로 변경되는 순간 레디스의 Zset의 멤버가 0 이 되면서 레디스가 해당 Zset를 삭제하는데 동기화 로직에서 Zset에 있는 멤버만 동기화를 시도해서 1 -> 0으로 동기화되지 못하고 1로 남는 버그가 발생 -> 동기화를 할 때 실제 활성화된 콘텐츠의 시청자를 모두 동기화 하도록 변경

- 기존 redis Zset 의존 -> ES에서 시청자수가 0 이상인 콘텐츠에서 Redis 키가 없으면 0으로 초기화

## 검증 단계
<!-- 
PR을 적용하기 전에 확인한 사항과 테스트 방법을 작성해주세요.
예시:
1. 로컬 서버 실행 후 API 정상 동작 확인
2. 신규 기능 UI/UX 테스트 완료
3. 기존 기능 회귀 테스트 완료
-->

로컬 테스트

## 추가 코멘트
<!-- 팀원에게 공유할 필요가 있는 추가 정보나 주석 등을 작성해주세요.-->
